### PR TITLE
fix: prevent default animal flash on refresh

### DIFF
--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -321,7 +321,10 @@ async function expectReadableEnglishStoryLayout(
   expect(layout.documentScrollHeight).toBeLessThanOrEqual(viewport.height + 1)
   expect(layout.titleFontSize).toBeGreaterThanOrEqual(18)
   expect(layout.titleLineCount).toBe(1)
-  expect(layout.introLineCount).toBeLessThanOrEqual(5)
+  expect(
+    layout.introLineCount,
+    `${viewport.name}: introduction lines`,
+  ).toBeLessThanOrEqual(5)
 
   const compactLandscape =
     viewport.width > viewport.height && viewport.height <= 560
@@ -347,9 +350,10 @@ async function expectReadableEnglishStoryLayout(
 async function waitForMuseumShell(
   page: Page,
   heading: string,
+  level: 1 | 2 = 2,
 ): Promise<void> {
   await expect(page.locator('#museum-experience')).toBeVisible()
-  await expect(page.getByRole('heading', { level: 2, name: heading })).toBeVisible()
+  await expect(page.getByRole('heading', { level, name: heading })).toBeVisible()
 }
 
 async function waitForReadyAnimal(page: Page, animalId: string): Promise<void> {
@@ -546,8 +550,13 @@ test('switches language with the radio menu without reloading the page or model'
     }
   })
 
-  const response = await page.goto('./zh-CN/?animal=mammoth')
+  const response = await page.goto('./zh-CN/')
   expect(response?.ok()).toBe(true)
+  await waitForMuseumShell(page, '剑龙')
+  await waitForReadyAnimal(page, 'stegosaurus')
+  await page
+    .locator('a[data-animal-detail-link][data-animal-id="mammoth"]')
+    .click()
   await waitForMuseumShell(page, '长毛猛犸象')
   await waitForReadyAnimal(page, 'mammoth')
 
@@ -705,7 +714,11 @@ test('switches language with the radio menu without reloading the page or model'
   expect(glbRequests).toHaveLength(modelRequestCount)
 
   await page.reload()
-  await waitForMuseumShell(page, '长毛猛犸象')
+  await waitForMuseumShell(page, '长毛猛犸象', 1)
+  expect(new URL(page.url()).pathname).toBe(
+    `${nestedPath}zh-CN/animals/mammoth/`,
+  )
+  expect(new URL(page.url()).search).toBe('')
   await page
     .getByRole('button', { name: '切换语言，当前简体中文' })
     .click()
@@ -902,7 +915,7 @@ test('keeps representative English stories readable across responsive breakpoint
   for (const story of responsiveEnglishStoryCases) {
     const response = await page.goto(`./en/?animal=${story.animalId}`)
     expect(response?.ok()).toBe(true)
-    await waitForMuseumShell(page, story.heading)
+    await waitForMuseumShell(page, story.heading, 1)
 
     for (const viewport of responsiveStoryViewports) {
       await page.setViewportSize(viewport)
@@ -938,7 +951,7 @@ test('keeps the reported Retina phone and tablet layouts readable with touch inp
     await page.route('**/*.glb', (route) => route.abort())
     const response = await page.goto(`${baseURL}en/?animal=ichthyosaur`)
     expect(response?.ok()).toBe(true)
-    await waitForMuseumShell(page, 'Ichthyosaurs')
+    await waitForMuseumShell(page, 'Ichthyosaurs', 1)
     for (const viewport of viewports) {
       await page.setViewportSize(viewport)
       await expectReadableEnglishStoryLayout(page, viewport)

--- a/e2e/museum.spec.ts
+++ b/e2e/museum.spec.ts
@@ -1956,7 +1956,7 @@ test.describe('first-frame preview silhouette', () => {
       expect(response?.ok()).toBe(true)
       await expect(
         page.getByRole('heading', {
-          level: 'path' in viewport ? 1 : 2,
+          level: 1,
           name: 'Pachycephalosaurus',
         }),
       ).toBeVisible()

--- a/e2e/ssg-pilot.spec.ts
+++ b/e2e/ssg-pilot.spec.ts
@@ -236,6 +236,68 @@ test('hydrates a requested detail without flashing the default animal and exits 
   await expect(museum).toHaveAttribute('data-page-kind', 'museum')
 })
 
+test('normalizes a refreshed museum query to the matching static animal without flashing the default exhibit', async ({
+  page,
+}) => {
+  const hydrationErrors = collectHydrationErrors(page)
+  await page.addInitScript(() => {
+    const titleHistory: string[] = []
+    Object.defineProperty(window, '__museumAnimalTitleHistory', {
+      configurable: true,
+      value: titleHistory,
+    })
+    const recordTitle = () => {
+      const title = document.querySelector('.animal-title')?.textContent?.trim()
+      if (title && titleHistory.at(-1) !== title) {
+        titleHistory.push(title)
+      }
+    }
+    new MutationObserver(recordTitle).observe(document, {
+      characterData: true,
+      childList: true,
+      subtree: true,
+    })
+    document.addEventListener('DOMContentLoaded', recordTitle, { once: true })
+  })
+  const requestedModels: string[] = []
+  await page.route('**/*.glb*', (route) => {
+    requestedModels.push(route.request().url())
+    return route.abort()
+  })
+
+  await page.goto('./en/?animal=pachycephalosaurus')
+  await page.waitForURL('**/en/animals/pachycephalosaurus/')
+
+  const museum = page.locator('#museum-experience')
+  await expect(museum).toHaveAttribute('data-page-kind', 'animal-detail')
+  await expect(museum).toHaveAttribute(
+    'data-requested-animal-id',
+    'pachycephalosaurus',
+  )
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Pachycephalosaurus' }),
+  ).toBeVisible()
+  await expect(page.locator('.model-still img')).toHaveAttribute(
+    'alt',
+    'Still model of Pachycephalosaurus on a transparent background',
+  )
+
+  const titleHistory = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          __museumAnimalTitleHistory: string[]
+        }
+      ).__museumAnimalTitleHistory,
+  )
+  expect(titleHistory).toContain('Pachycephalosaurus')
+  expect(titleHistory).not.toContain('Stegosaurus')
+  expect(
+    requestedModels.some((url) => url.includes('/stegosaurus/')),
+  ).toBe(false)
+  expect(hydrationErrors).toEqual([])
+})
+
 test('shows the default Chinese museum immediately when the edge redirect fails open', async ({
   page,
 }) => {

--- a/scripts/prerender-localized-museum.ts
+++ b/scripts/prerender-localized-museum.ts
@@ -19,6 +19,18 @@ function serialiseBootstrap(state: InitialAppState): string {
     .replaceAll('\u2029', '\\u2029')
 }
 
+function renderMuseumQueryRedirect(state: InitialAppState): string {
+  if (state.pageKind !== 'museum') {
+    return ''
+  }
+
+  const detailBase = state.rootFallback
+    ? `./${state.locale}/animals/`
+    : './animals/'
+  const animalIds = JSON.stringify(staticAnimalDetailIds)
+  return `<script data-museum-query-redirect>(function(){var p=new URLSearchParams(location.search),a=p.get('animal');if(!a||!${animalIds}.includes(a))return;p.delete('animal');var u=new URL(${JSON.stringify(detailBase)}+encodeURIComponent(a)+'/',location.href);u.search=p.toString();u.hash=location.hash;history.replaceState(history.state,'',u.href);location.reload()})()</script>`
+}
+
 function rebaseApplicationAssets(
   markup: string,
   assetBase: './assets/' | '../assets/' | '../../../assets/',
@@ -64,7 +76,11 @@ export function renderPrerenderedMuseumDocument(
         : '../assets/',
   )}${documentSource.slice(end)}`
   const bootstrap = `<script id="${appBootstrapElementId}" type="application/json">${serialiseBootstrap(state)}</script>`
-  return withMarkup.replace('</head>', `    ${bootstrap}\n  </head>`)
+  const queryRedirect = renderMuseumQueryRedirect(state)
+  return withMarkup.replace(
+    '</head>',
+    `    ${bootstrap}${queryRedirect ? `\n    ${queryRedirect}` : ''}\n  </head>`,
+  )
 }
 
 export async function writeLocalizedMuseumPrerenders(

--- a/src/styles.css
+++ b/src/styles.css
@@ -3889,7 +3889,7 @@ a:focus-visible {
   }
 }
 
-@media (max-width: 1023px) and (min-width: 768px) and (orientation: landscape) {
+@media (max-width: 1023px) and (min-width: 768px) and (orientation: landscape) and (max-height: 560px) {
   .museum-experience[data-page-kind="animal-detail"] .story-actions {
     grid-template-columns:
       minmax(0, 1fr)


### PR DESCRIPTION
## Summary
- normalize valid `?animal=` refreshes to the matching localized static detail route before the museum body is painted
- preserve history state, remaining query parameters, hashes, and system-language preference across normalization
- prevent the Stegosaurus model from being requested for a different animal deep link
- keep English detail actions from squeezing story content at short tablet-landscape boundaries

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run` (302 passed)
- `npm run test:e2e` (77 passed)
- `npm run build:cloudflare`