### PR TITLE
fix: unify land encounter locomotion

### DIFF
--- a/src/viewer/ViewerController.ts
+++ b/src/viewer/ViewerController.ts
@@ -49,6 +49,8 @@ import {
 import type { ViewerModelDescriptor } from './viewer-model-descriptor'
 import {
   SCALE_ENCOUNTER_DEFINITIONS,
+  SCALE_ENCOUNTER_LAND_RUN_SPEED_METERS_PER_SECOND,
+  SCALE_ENCOUNTER_LAND_WALK_SPEED_METERS_PER_SECOND,
   clampScaleEncounterValue,
   computeScaleEncounterAvatarGroundedEyeHeight,
   computeScaleEncounterAvatarTravelQuaternion,
@@ -57,6 +59,7 @@ import {
   isScaleEncounterAnimalId,
   normalizeScaleEncounterProfile,
   positionOnScaleEncounterRail,
+  resolveScaleEncounterLandInputIntent,
   scaleEncounterAvatarMotionFor,
   scaleEncounterSubjectLayoutForAspect,
   updateScaleEncounterAvatarIdle,
@@ -379,6 +382,7 @@ interface ScaleEncounterRuntime {
   jumpPhase: 'grounded' | 'anticipation' | 'airborne' | 'landing'
   jumpPhaseElapsedSeconds: number
   jumpVelocityMetersPerSecond: number
+  landMotionIntent: 'idle' | 'walk' | 'run'
   mammothAnimalGrade: MammothSubjectGradeLease | null
   oceanAnimalGrade: OceanSubjectGradeLease | null
   oceanAvatarGrade: OceanSubjectGradeLease | null
@@ -422,9 +426,7 @@ function scaleEncounterOrbitTravelSpeedMetersPerSecond(
 ): number {
   if (definition.habitat === 'air') return 4
   if (definition.habitat === 'water') return 1.2
-  if (definition.environmentTheme === 'glacier') return 1.4
-  if (definition.displayedMeters <= 1) return 1
-  return 2.8
+  return SCALE_ENCOUNTER_LAND_RUN_SPEED_METERS_PER_SECOND
 }
 const SCALE_ENCOUNTER_ORBIT_EASING_PER_SECOND = 10
 const SCALE_ENCOUNTER_AIR_BOOST_MULTIPLIER = 1.6
@@ -622,6 +624,7 @@ function scaleEncounterOverviewAxes(
 }
 const SCALE_ENCOUNTER_DISTANCE_HOLD_STEPS_PER_SECOND = 4
 const SCALE_ENCOUNTER_DISTANCE_EASING_PER_SECOND = 14
+const SCALE_ENCOUNTER_LAND_SWEEP_STEP_METERS = 0.01
 // Keep a grounded first-person camera well above both the land plane
 // (y = -0.035) and its 3 cm near plane, even if a future avatar has a
 // malformed eye anchor. Reviewed child avatars sit much higher than this.
@@ -668,8 +671,11 @@ export function viewerZoomProfileForPointer(
  * different child eye anchor, below) the land plane.
  *
  * On land the useful interaction is a horizontal dolly at the child's eye
- * height. `distance` remains the true eye-to-target distance, while the camera
- * moves on one fixed horizontal axis. Air and water retain their authored
+ * height. Existing animals retain their reviewed head-relative rail.
+ * Apatosaurus alone uses a body-centred linear radius: rotating its old
+ * head-relative rail around a 23 m body left an irreducible multi-metre gap at
+ * the legs, while the slant-distance projection collapsed the last part of an
+ * approach into a visible forward snap. Air and water retain their authored
  * three-dimensional rails unchanged.
  */
 export function computeScaleEncounterPovEyePosition(
@@ -691,21 +697,27 @@ export function computeScaleEncounterPovEyePosition(
     placement.defaultEyePosition.y,
     SCALE_ENCOUNTER_GROUNDED_CAMERA_MINIMUM_HEIGHT,
   )
-  const verticalDistance = placement.target.y - eyeHeight
-  const horizontalDistance = Math.sqrt(
-    Math.max(distance * distance - verticalDistance * verticalDistance, 0),
-  )
-  result.copy(placement.observerRailDirection).setY(0)
-  if (result.lengthSq() < 1e-8) {
-    result.copy(placement.defaultEyePosition).sub(placement.target).setY(0)
+  if (placement.animalId !== 'apatosaurus') {
+    const verticalDistance = placement.target.y - eyeHeight
+    const horizontalDistance = Math.sqrt(
+      Math.max(distance * distance - verticalDistance * verticalDistance, 0),
+    )
+    result.copy(placement.observerRailDirection).setY(0)
+    if (result.lengthSq() < 1e-8) {
+      result.copy(placement.defaultEyePosition).sub(placement.target).setY(0)
+    }
+    if (result.lengthSq() < 1e-8) result.set(-1, 0, 0)
+    return result
+      .normalize()
+      .multiplyScalar(horizontalDistance)
+      .add(placement.target)
+      .setY(eyeHeight)
   }
-  if (result.lengthSq() < 1e-8) {
-    result.set(-1, 0, 0)
-  }
+  result.copy(placement.defaultEyePosition).sub(placement.orbitCenter).setY(0)
+  if (result.lengthSq() < 1e-8) result.set(-1, 0, 0)
   return result
-    .normalize()
-    .multiplyScalar(horizontalDistance)
-    .add(placement.target)
+    .multiplyScalar(distance / Math.max(placement.defaultDistance, 1e-8))
+    .add(placement.orbitCenter)
     .setY(eyeHeight)
 }
 
@@ -732,6 +744,105 @@ export function computeScaleEncounterOrbitedEyePosition(
     .sub(placement.orbitCenter)
     .applyAxisAngle(WORLD_UP, orbitAngleRadians)
     .add(placement.orbitCenter)
+}
+
+/** Horizontal world radius produced by a rail parameter at any orbit angle. */
+export function scaleEncounterLandRadiusAtDistance(
+  placement: ScaleEncounterPlacement,
+  distance: number,
+): number {
+  const eye = computeScaleEncounterPovEyePosition(placement, 'land', distance)
+  const radius = eye.sub(placement.orbitCenter).setY(0).length()
+  return Number.isFinite(radius) ? radius : 0
+}
+
+/**
+ * Inverts a land animal's existing observation rail by world radius. This is
+ * what keeps 1.4/2.8 m/s honest on both the legacy slant-distance rails and
+ * Apatosaurus's body-centred linear rail without changing either composition.
+ */
+export function scaleEncounterLandDistanceForRadius(
+  placement: ScaleEncounterPlacement,
+  desiredRadius: number,
+  minimumDistance: number,
+  maximumDistance: number,
+): number {
+  const lowerDistance = Math.min(minimumDistance, maximumDistance)
+  const upperDistance = Math.max(minimumDistance, maximumDistance)
+  const lowerRadius = scaleEncounterLandRadiusAtDistance(
+    placement,
+    lowerDistance,
+  )
+  const upperRadius = scaleEncounterLandRadiusAtDistance(
+    placement,
+    upperDistance,
+  )
+  if (
+    !Number.isFinite(desiredRadius) ||
+    !Number.isFinite(lowerRadius) ||
+    !Number.isFinite(upperRadius)
+  ) {
+    return lowerDistance
+  }
+  const increasing = upperRadius >= lowerRadius
+  const clampedRadius = MathUtils.clamp(
+    desiredRadius,
+    Math.min(lowerRadius, upperRadius),
+    Math.max(lowerRadius, upperRadius),
+  )
+  let low = lowerDistance
+  let high = upperDistance
+  for (let iteration = 0; iteration < 32; iteration += 1) {
+    const midpoint = (low + high) * 0.5
+    const radius = scaleEncounterLandRadiusAtDistance(placement, midpoint)
+    if ((radius < clampedRadius) === increasing) low = midpoint
+    else high = midpoint
+  }
+  return (low + high) * 0.5
+}
+
+function projectScaleEncounterLandPointOutsideBounds(
+  point: Vector3,
+  minimum: Readonly<Vector3>,
+  maximum: Readonly<Vector3>,
+): Vector3 {
+  if (
+    point.x <= minimum.x ||
+    point.x >= maximum.x ||
+    point.z <= minimum.z ||
+    point.z >= maximum.z
+  ) {
+    return point
+  }
+  const candidates = [
+    { distance: point.x - minimum.x, axis: 'x' as const, value: minimum.x },
+    { distance: maximum.x - point.x, axis: 'x' as const, value: maximum.x },
+    { distance: point.z - minimum.z, axis: 'z' as const, value: minimum.z },
+    { distance: maximum.z - point.z, axis: 'z' as const, value: maximum.z },
+  ]
+  const closest = candidates.reduce((best, candidate) =>
+    candidate.distance < best.distance ? candidate : best,
+  )
+  point[closest.axis] = closest.value
+  return point
+}
+
+function unwrapScaleEncounterOrbitAngle(
+  previousAngle: number,
+  baseDirection: Readonly<Vector3>,
+  nextDirection: Readonly<Vector3>,
+): number {
+  const wrapped = Math.atan2(
+    baseDirection.z * nextDirection.x -
+      baseDirection.x * nextDirection.z,
+    baseDirection.x * nextDirection.x +
+      baseDirection.z * nextDirection.z,
+  )
+  const delta = MathUtils.euclideanModulo(
+    wrapped - previousAngle + Math.PI,
+    Math.PI * 2,
+  ) - Math.PI
+  return previousAngle + delta
 }
 
 function scaleEncounterEyeClearsExpandedAnimalBounds(
@@ -800,13 +911,20 @@ export function minimumScaleEncounterDistanceForProfile(
   profile: NormalizedScaleEncounterProfile,
   orbitAngleRadians: number,
 ): number {
-  if (profile.approach !== 'close') return definition.minimumDistance
-
+  if (
+    profile.approach !== 'close' &&
+    placement.animalId !== 'apatosaurus'
+  ) {
+    return definition.minimumDistance
+  }
   const marginMeters = Math.max(0.55, profile.heightMeters * 0.5)
-  const distanceFloor = Math.min(
-    definition.minimumDistance,
-    Math.max(0.75, profile.heightMeters * 0.75),
-  )
+  const distanceFloor =
+    profile.approach === 'close'
+      ? Math.min(
+          definition.minimumDistance,
+          Math.max(0.75, profile.heightMeters * 0.75),
+        )
+      : definition.minimumDistance
   const clearsAt = (distance: number) =>
     scaleEncounterEyeClearsExpandedAnimalBounds(
       placement,
@@ -2032,6 +2150,7 @@ export class ViewerController {
         jumpPhase: 'grounded',
         jumpPhaseElapsedSeconds: 0,
         jumpVelocityMetersPerSecond: 0,
+        landMotionIntent: 'idle',
         mammothAnimalGrade,
         oceanAnimalGrade,
         oceanAvatarGrade,
@@ -2553,6 +2672,12 @@ export class ViewerController {
       // target prevents an ease from being added on top of the linear dolly.
       encounter.targetOverviewZoom = encounter.overviewZoom
       encounter.targetObserverDistance = encounter.observerDistance
+      if (
+        encounter.view === 'pov' &&
+        encounter.definition.habitat === 'land'
+      ) {
+        encounter.targetOrbitAngleRadians = encounter.orbitAngleRadians
+      }
     } else {
       this.publishScaleEncounterSnapshot()
     }
@@ -2595,6 +2720,9 @@ export class ViewerController {
     encounter.orbitMotionDirection = direction
     if (direction !== 0) {
       encounter.targetOrbitAngleRadians = encounter.orbitAngleRadians
+      if (encounter.definition.habitat === 'land') {
+        encounter.targetObserverDistance = encounter.observerDistance
+      }
     } else {
       this.publishScaleEncounterSnapshot()
     }
@@ -2826,6 +2954,26 @@ export class ViewerController {
     const encounter = this.scaleEncounter
     if (!encounter || encounter.transition) return
 
+    if (
+      encounter.view === 'pov' &&
+      encounter.definition.habitat === 'land' &&
+      (encounter.distanceMotionDirection !== 0 ||
+        encounter.orbitMotionDirection !== 0)
+    ) {
+      this.updateScaleEncounterLandHeldMotion(deltaSeconds, now)
+      return
+    }
+
+    if (encounter.definition.habitat === 'land') {
+      encounter.landMotionIntent =
+        encounter.view === 'pov' &&
+        Math.abs(
+          encounter.targetObserverDistance - encounter.observerDistance,
+        ) > 1e-7
+          ? 'walk'
+          : 'idle'
+    }
+
     const heldDirection = encounter.distanceMotionDirection
     const isOverview = encounter.view === 'overview'
     let changed: boolean
@@ -2878,6 +3026,39 @@ export class ViewerController {
           encounter.orbitAngleRadians,
         )
         encounter.targetObserverDistance = encounter.observerDistance
+      } else if (encounter.definition.habitat === 'land') {
+        const targetRadius = scaleEncounterLandRadiusAtDistance(
+          encounter.placement,
+          encounter.targetObserverDistance,
+        )
+        const previousRadius = scaleEncounterLandRadiusAtDistance(
+          encounter.placement,
+          previous,
+        )
+        const maximumWorldStep =
+          SCALE_ENCOUNTER_LAND_WALK_SPEED_METERS_PER_SECOND *
+          Math.max(deltaSeconds, 0)
+        const remainingRadius = targetRadius - previousRadius
+        const nextRadius =
+          previousRadius +
+          Math.sign(remainingRadius) *
+            Math.min(Math.abs(remainingRadius), maximumWorldStep)
+        const minimumDistance = minimumScaleEncounterDistanceForProfile(
+          encounter.placement,
+          encounter.definition,
+          encounter.profile,
+          encounter.orbitAngleRadians,
+        )
+        encounter.observerDistance = scaleEncounterLandDistanceForRadius(
+          encounter.placement,
+          nextRadius,
+          minimumDistance,
+          encounter.definition.maximumDistance,
+        )
+        if (Math.abs(remainingRadius) <= maximumWorldStep + 1e-8) {
+          encounter.observerDistance = encounter.targetObserverDistance
+          settled = true
+        }
       } else {
         const alpha = 1 - Math.exp(
           -SCALE_ENCOUNTER_DISTANCE_EASING_PER_SECOND * deltaSeconds,
@@ -2917,14 +3098,213 @@ export class ViewerController {
     }
   }
 
+  /**
+   * Integrates both axes as one normalised local-polar command. Small world
+   * substeps are the swept equivalent used here: every segment is projected
+   * onto the angle-dependent safe radius before the next segment begins, so a
+   * long frame cannot penetrate and then trigger a large corrective snap.
+   */
+  private updateScaleEncounterLandHeldMotion(
+    deltaSeconds: number,
+    now: number,
+  ): void {
+    const encounter = this.scaleEncounter
+    if (
+      !encounter ||
+      encounter.transition ||
+      encounter.view !== 'pov' ||
+      encounter.definition.habitat !== 'land'
+    ) {
+      return
+    }
+    const intent = resolveScaleEncounterLandInputIntent(
+      encounter.distanceMotionDirection,
+      encounter.orbitMotionDirection,
+    )
+    if (intent.motion === 'idle' || deltaSeconds <= 0) return
+    encounter.landMotionIntent = intent.motion
+
+    const previousDistance = encounter.observerDistance
+    const previousAngle = encounter.orbitAngleRadians
+    const travelMeters = intent.speedMetersPerSecond * deltaSeconds
+    const substepCount = Math.max(
+      1,
+      Math.ceil(travelMeters / SCALE_ENCOUNTER_LAND_SWEEP_STEP_METERS),
+    )
+    const substepSeconds = deltaSeconds / substepCount
+    const usesExpandedAnimalBounds =
+      encounter.profile.approach === 'close' ||
+      encounter.placement.animalId === 'apatosaurus'
+    const collisionMarginMeters = Math.max(
+      0.55,
+      encounter.profile.heightMeters * 0.5,
+    )
+    const collisionMinimum = encounter.placement.animalBoundsMinimum
+      .clone()
+      .addScalar(-collisionMarginMeters)
+    const collisionMaximum = encounter.placement.animalBoundsMaximum
+      .clone()
+      .addScalar(collisionMarginMeters)
+    const baseDirection = computeScaleEncounterPovEyePosition(
+      encounter.placement,
+      'land',
+      encounter.placement.defaultDistance,
+    )
+      .sub(encounter.placement.orbitCenter)
+      .setY(0)
+      .normalize()
+
+    for (let step = 0; step < substepCount; step += 1) {
+      if (usesExpandedAnimalBounds) {
+        const currentEye = computeScaleEncounterOrbitedEyePosition(
+          encounter.placement,
+          'land',
+          encounter.observerDistance,
+          encounter.orbitAngleRadians,
+        ).setY(0)
+        const outward = currentEye
+          .clone()
+          .sub(encounter.placement.orbitCenter)
+          .setY(0)
+          .normalize()
+        const tangent = new Vector3(outward.z, 0, -outward.x)
+        const nextEye = currentEye
+          .clone()
+          .addScaledVector(
+            outward,
+            -intent.radial *
+              intent.speedMetersPerSecond *
+              substepSeconds,
+          )
+          .addScaledVector(
+            tangent,
+            intent.tangential *
+              intent.speedMetersPerSecond *
+              substepSeconds,
+          )
+        projectScaleEncounterLandPointOutsideBounds(
+          nextEye,
+          collisionMinimum,
+          collisionMaximum,
+        )
+        const nextOffset = nextEye
+          .sub(encounter.placement.orbitCenter)
+          .setY(0)
+        const maximumRadius = scaleEncounterLandRadiusAtDistance(
+          encounter.placement,
+          encounter.definition.maximumDistance,
+        )
+        if (nextOffset.length() > maximumRadius) {
+          nextOffset.setLength(maximumRadius)
+        }
+        const nextRadius = Math.max(nextOffset.length(), 0.001)
+        const nextDirection = nextOffset.clone().divideScalar(nextRadius)
+        const nextAngle = unwrapScaleEncounterOrbitAngle(
+          encounter.orbitAngleRadians,
+          baseDirection,
+          nextDirection,
+        )
+        const minimumDistance = minimumScaleEncounterDistanceForProfile(
+          encounter.placement,
+          encounter.definition,
+          encounter.profile,
+          nextAngle,
+        )
+        encounter.orbitAngleRadians = nextAngle
+        encounter.observerDistance = scaleEncounterLandDistanceForRadius(
+          encounter.placement,
+          nextRadius,
+          minimumDistance,
+          encounter.definition.maximumDistance,
+        )
+        continue
+      }
+
+      const radius = Math.max(
+        scaleEncounterLandRadiusAtDistance(
+          encounter.placement,
+          encounter.observerDistance,
+        ),
+        0.001,
+      )
+      const nextAngle =
+        encounter.orbitAngleRadians +
+        (intent.tangential *
+          intent.speedMetersPerSecond *
+          substepSeconds) /
+          radius
+      const minimumDistance = minimumScaleEncounterDistanceForProfile(
+        encounter.placement,
+        encounter.definition,
+        encounter.profile,
+        nextAngle,
+      )
+      const minimumRadius = scaleEncounterLandRadiusAtDistance(
+        encounter.placement,
+        minimumDistance,
+      )
+      const maximumRadius = scaleEncounterLandRadiusAtDistance(
+        encounter.placement,
+        encounter.definition.maximumDistance,
+      )
+      const desiredRadius =
+        radius -
+        intent.radial * intent.speedMetersPerSecond * substepSeconds
+      const nextRadius = MathUtils.clamp(
+        desiredRadius,
+        Math.min(minimumRadius, maximumRadius),
+        Math.max(minimumRadius, maximumRadius),
+      )
+      encounter.orbitAngleRadians = Number.isFinite(nextAngle)
+        ? nextAngle
+        : encounter.orbitAngleRadians
+      encounter.observerDistance = scaleEncounterLandDistanceForRadius(
+        encounter.placement,
+        nextRadius,
+        minimumDistance,
+        encounter.definition.maximumDistance,
+      )
+    }
+
+    encounter.targetObserverDistance = encounter.observerDistance
+    encounter.targetOrbitAngleRadians = encounter.orbitAngleRadians
+    const changed =
+      Math.abs(encounter.observerDistance - previousDistance) > 1e-7 ||
+      Math.abs(encounter.orbitAngleRadians - previousAngle) > 1e-7
+    if (!changed) return
+    this.applyScaleEncounterPovPose()
+    if (now - this.scaleEncounterDistanceSnapshotUpdatedAt >= 50) {
+      this.scaleEncounterDistanceSnapshotUpdatedAt = now
+      this.publishScaleEncounterSnapshot()
+    }
+  }
+
   private updateScaleEncounterOrbit(
     deltaSeconds: number,
     now: number,
   ): void {
     const encounter = this.scaleEncounter
     if (!encounter || encounter.transition || encounter.view !== 'pov') return
+    if (
+      encounter.definition.habitat === 'land' &&
+      (encounter.distanceMotionDirection !== 0 ||
+        encounter.orbitMotionDirection !== 0)
+    ) {
+      return
+    }
 
     const previous = encounter.orbitAngleRadians
+    const hasOrbitIntent =
+      encounter.orbitMotionDirection !== 0 ||
+      Math.abs(
+        encounter.targetOrbitAngleRadians - encounter.orbitAngleRadians,
+      ) > 0.0002
+    if (
+      encounter.definition.habitat === 'land' &&
+      hasOrbitIntent
+    ) {
+      encounter.landMotionIntent = 'run'
+    }
     const horizontalOrbitRadius = Math.max(
       encounter.avatar.eyeAnchor
         .getWorldPosition(new Vector3())
@@ -4222,11 +4602,18 @@ export class ViewerController {
     // along the measured travel vector.
     this.placeScaleEncounterAvatarEyeAt(encounter.avatar, eyePosition)
     encounter.avatarPreviousEyePosition.copy(eyePosition)
+    let motionKind = scaleEncounterAvatarMotionFor(
+      encounter.definition.id,
+      speedMetersPerSecond,
+    )
+    if (encounter.definition.habitat === 'land') {
+      motionKind =
+        encounter.view !== 'pov'
+          ? 'idle'
+          : (encounter.landMotionIntent ?? 'idle')
+    }
     const motionState = {
-      kind: scaleEncounterAvatarMotionFor(
-        encounter.definition.id,
-        speedMetersPerSecond,
-      ),
+      kind: motionKind,
       speedMetersPerSecond,
     }
     encounter.avatar.setMotionState?.(motionState)

--- a/src/viewer/scale-encounter.ts
+++ b/src/viewer/scale-encounter.ts
@@ -47,6 +47,49 @@ export interface ScaleEncounterAvatarMotionState {
   readonly kind: ScaleEncounterAvatarMotion
   readonly speedMetersPerSecond: number
 }
+
+export const SCALE_ENCOUNTER_LAND_WALK_SPEED_METERS_PER_SECOND = 1.4
+export const SCALE_ENCOUNTER_LAND_RUN_SPEED_METERS_PER_SECOND = 2.8
+
+export interface ScaleEncounterLandInputIntent {
+  /** Positive values move toward the animal. */
+  readonly radial: number
+  /** Positive values circle right around the animal. */
+  readonly tangential: number
+  readonly motion: Extract<ScaleEncounterAvatarMotion, 'idle' | 'walk' | 'run'>
+  readonly speedMetersPerSecond: number
+}
+
+/**
+ * Resolves land controls before any rail mapping or collision projection.
+ * Gait belongs to the user's intent, while geometry is only allowed to limit
+ * the final position. Normalising here prevents diagonal inputs from adding a
+ * 1.4 m/s radial vector to an independent 2.8 m/s tangent vector.
+ */
+export function resolveScaleEncounterLandInputIntent(
+  radialDirection: -1 | 0 | 1,
+  tangentialDirection: -1 | 0 | 1,
+): ScaleEncounterLandInputIntent {
+  if (radialDirection === 0 && tangentialDirection === 0) {
+    return {
+      motion: 'idle',
+      radial: 0,
+      speedMetersPerSecond: 0,
+      tangential: 0,
+    }
+  }
+  const magnitude = Math.hypot(radialDirection, tangentialDirection)
+  const motion = tangentialDirection === 0 ? 'walk' : 'run'
+  return {
+    motion,
+    radial: radialDirection / magnitude,
+    speedMetersPerSecond:
+      motion === 'run'
+        ? SCALE_ENCOUNTER_LAND_RUN_SPEED_METERS_PER_SECOND
+        : SCALE_ENCOUNTER_LAND_WALK_SPEED_METERS_PER_SECOND,
+    tangential: tangentialDirection / magnitude,
+  }
+}
 export type ScaleEncounterCameraStage =
   | 'overview'
   | 'side-establishing'
@@ -132,6 +175,7 @@ export interface ScaleEncounterDefinition {
 }
 
 export interface ScaleEncounterPlacement {
+  readonly animalId: ScaleEncounterAnimalId
   /** Complete calibrated world-space bounds used by close approach. */
   readonly animalBoundsMaximum: Readonly<Vector3>
   readonly animalBoundsMinimum: Readonly<Vector3>
@@ -424,7 +468,7 @@ export const SCALE_ENCOUNTER_DEFINITIONS: Readonly<
     habitat: 'land',
     environmentTheme: 'forest',
     avatarProfile: 'land-explorer',
-    avatarMotionPolicy: 'walk-only',
+    avatarMotionPolicy: 'adaptive-land',
     calibratedModelSha256:
       '9d9f151933a33ae5824eb7532e16a7416b012b9ffff154aca2957ad37a2a540a',
     displayedMeters: 23,
@@ -542,7 +586,7 @@ export const SCALE_ENCOUNTER_DEFINITIONS: Readonly<
     habitat: 'land',
     environmentTheme: 'glacier',
     avatarProfile: 'snow-expedition',
-    avatarMotionPolicy: 'walk-only',
+    avatarMotionPolicy: 'adaptive-land',
     calibratedModelSha256:
       '623a62621f1c6f2955fd3fe6442be8dfd34cdc94064e1bbb0c5e43e8970a1ece',
     // Published sources give a 3–3.5 m adult shoulder-height range. The
@@ -657,7 +701,7 @@ export const SCALE_ENCOUNTER_DEFINITIONS: Readonly<
     habitat: 'land',
     environmentTheme: 'forest',
     avatarProfile: 'land-explorer',
-    avatarMotionPolicy: 'walk-only',
+    avatarMotionPolicy: 'adaptive-land',
     calibratedModelSha256:
       '4e388ade5b32132cc60054fa51dc7ac0fe48372efafaf4c57732697b3874589b',
     displayedMeters: 0.7,
@@ -957,6 +1001,7 @@ export function createScaleEncounterPlacement(
     definition.defaultDistance,
   )
   return {
+    animalId,
     animalBoundsMaximum: new Vector3().copy(boundsMaximum),
     animalBoundsMinimum: new Vector3().copy(boundsMinimum),
     orbitCenter,

--- a/tests/scale-encounter-geometry.test.ts
+++ b/tests/scale-encounter-geometry.test.ts
@@ -1,20 +1,25 @@
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { Vector3 } from 'three'
+import { MathUtils, Vector3 } from 'three'
 import {
   SCALE_ENCOUNTER_DEFINITIONS,
+  SCALE_ENCOUNTER_LAND_RUN_SPEED_METERS_PER_SECOND,
+  SCALE_ENCOUNTER_LAND_WALK_SPEED_METERS_PER_SECOND,
   clampScaleEncounterDistance,
   computeScaleEncounterAvatarTravelQuaternion,
   createScaleEncounterPlacement,
   normalizeScaleEncounterProfile,
   positionOnScaleEncounterRail,
+  resolveScaleEncounterLandInputIntent,
   scaleEncounterAvatarMotionFor,
   scaleEncounterElevationDegrees,
 } from '../src/viewer/scale-encounter'
 import { SCALE_ENCOUNTER_ANIMAL_IDS } from '../src/scale-encounter/types'
 import {
   clampScaleEncounterDistanceForProfile,
+  computeScaleEncounterOrbitedEyePosition,
+  computeScaleEncounterPovEyePosition,
   minimumScaleEncounterDistanceForProfile,
 } from '../src/viewer/ViewerController'
 
@@ -118,8 +123,8 @@ describe('scale encounter geometry', () => {
       Math.PI / 2,
     )
 
-    expect(headSideMinimum).toBeLessThan(definition.minimumDistance)
-    expect(broadsideMinimum).not.toBeCloseTo(headSideMinimum, 2)
+    expect(headSideMinimum).toBeGreaterThan(definition.minimumDistance)
+    expect(broadsideMinimum).toBeLessThan(definition.minimumDistance)
     expect(
       clampScaleEncounterDistanceForProfile(
         placement,
@@ -128,7 +133,7 @@ describe('scale encounter geometry', () => {
         0,
         0,
       ),
-    ).toBe(definition.minimumDistance)
+    ).toBeCloseTo(headSideMinimum, 5)
     expect(
       clampScaleEncounterDistanceForProfile(
         placement,
@@ -138,6 +143,141 @@ describe('scale encounter geometry', () => {
         0,
       ),
     ).toBeCloseTo(headSideMinimum, 5)
+  })
+
+  it('lets a close Apatosaurus observer reach the broadside legs without a forward jump', () => {
+    const definition = SCALE_ENCOUNTER_DEFINITIONS.apatosaurus
+    const placement = createScaleEncounterPlacement(
+      'apatosaurus',
+      new Vector3(-8, 0, -1.5),
+      new Vector3(15, 5, 1.5),
+      1.1,
+    )
+    const profile = normalizeScaleEncounterProfile({
+      approach: 'close',
+      gender: 'girl',
+      heightCm: 110,
+    })
+    const orbitAngleRadians = Math.PI / 2
+    const minimum = minimumScaleEncounterDistanceForProfile(
+      placement,
+      definition,
+      profile,
+      orbitAngleRadians,
+    )
+    const atMinimum = computeScaleEncounterOrbitedEyePosition(
+      placement,
+      definition.habitat,
+      minimum,
+      orbitAngleRadians,
+    )
+    const oneStepFarther = computeScaleEncounterOrbitedEyePosition(
+      placement,
+      definition.habitat,
+      minimum + 0.35,
+      orbitAngleRadians,
+    )
+    const twoStepsFarther = computeScaleEncounterOrbitedEyePosition(
+      placement,
+      definition.habitat,
+      minimum + 0.7,
+      orbitAngleRadians,
+    )
+    const firstStep = oneStepFarther.distanceTo(atMinimum)
+    const secondStep = twoStepsFarther.distanceTo(oneStepFarther)
+    const broadsideRadius = atMinimum
+      .clone()
+      .sub(placement.orbitCenter)
+      .setY(0)
+      .length()
+
+    expect(broadsideRadius).toBeLessThan(3)
+    expect(firstStep).toBeGreaterThan(0.1)
+    expect(secondStep).toBeCloseTo(firstStep, 8)
+  })
+
+  it.each([
+    ['front-left leg side', MathUtils.degToRad(60)],
+    ['rear-left leg side', MathUtils.degToRad(120)],
+    ['rear-right leg side', MathUtils.degToRad(240)],
+    ['front-right leg side', MathUtils.degToRad(300)],
+  ])('reaches the safe boundary beside the %s', (_label, angle) => {
+    const definition = SCALE_ENCOUNTER_DEFINITIONS.apatosaurus
+    const placement = createScaleEncounterPlacement(
+      'apatosaurus',
+      new Vector3(-8, 0, -1.5),
+      new Vector3(15, 5, 1.5),
+      1.1,
+    )
+    const profile = normalizeScaleEncounterProfile({
+      approach: 'close',
+      gender: 'girl',
+      heightCm: 110,
+    })
+    const minimum = minimumScaleEncounterDistanceForProfile(
+      placement,
+      definition,
+      profile,
+      angle,
+    )
+    const boundary = computeScaleEncounterOrbitedEyePosition(
+      placement,
+      'land',
+      minimum,
+      angle,
+    )
+    const radius = boundary
+      .clone()
+      .sub(placement.orbitCenter)
+      .setY(0)
+      .length()
+    const farther = computeScaleEncounterOrbitedEyePosition(
+      placement,
+      'land',
+      minimum + 0.1,
+      angle,
+    )
+
+    expect(Number.isFinite(minimum)).toBe(true)
+    expect(radius).toBeLessThan(3)
+    expect(farther.distanceTo(boundary)).toBeGreaterThan(0)
+    expect(farther.distanceTo(boundary)).toBeLessThan(0.5)
+  })
+
+  it.each(
+    SCALE_ENCOUNTER_ANIMAL_IDS.filter(
+      (animalId) =>
+        animalId !== 'apatosaurus' &&
+        SCALE_ENCOUNTER_DEFINITIONS[animalId].habitat === 'land',
+    ).map((animalId) => [animalId, animalId] as const),
+  )('keeps the existing head-relative ground rail for %s', (animalId) => {
+    const definition = SCALE_ENCOUNTER_DEFINITIONS[animalId]
+    const placement = createScaleEncounterPlacement(
+      animalId,
+      new Vector3(-4, 0, -1),
+      new Vector3(6, 4, 1),
+      1.1,
+    )
+    const distance = definition.maximumDistance
+    const eye = computeScaleEncounterPovEyePosition(
+      placement,
+      definition.habitat,
+      distance,
+    )
+    const eyeHeight = placement.defaultEyePosition.y
+    const verticalDistance = placement.target.y - eyeHeight
+    const horizontalDistance = Math.sqrt(
+      Math.max(distance * distance - verticalDistance * verticalDistance, 0),
+    )
+    const expected = placement.observerRailDirection
+      .clone()
+      .setY(0)
+      .normalize()
+      .multiplyScalar(horizontalDistance)
+      .add(placement.target)
+      .setY(eyeHeight)
+
+    expect(eye.distanceTo(expected)).toBeLessThan(1e-9)
   })
 
   it.each([
@@ -385,10 +525,40 @@ describe('scale encounter geometry', () => {
     expect(scaleEncounterAvatarMotionFor('tyrannosaurus-rex', 0)).toBe('idle')
     expect(scaleEncounterAvatarMotionFor('tyrannosaurus-rex', 1.4)).toBe('walk')
     expect(scaleEncounterAvatarMotionFor('tyrannosaurus-rex', 2.2)).toBe('run')
-    expect(scaleEncounterAvatarMotionFor('mammoth', 4)).toBe('walk')
+    expect(scaleEncounterAvatarMotionFor('apatosaurus', 1.4)).toBe('walk')
+    expect(scaleEncounterAvatarMotionFor('apatosaurus', 2.8)).toBe('run')
+    expect(scaleEncounterAvatarMotionFor('mammoth', 4)).toBe('run')
+    expect(scaleEncounterAvatarMotionFor('meganeura', 4)).toBe('run')
     expect(scaleEncounterAvatarMotionFor('pteranodon', 0)).toBe('glide')
     expect(scaleEncounterAvatarMotionFor('pteranodon', 8)).toBe('glide')
     expect(scaleEncounterAvatarMotionFor('mosasaurus', 0)).toBe('idle')
     expect(scaleEncounterAvatarMotionFor('mosasaurus', 0.8)).toBe('swim')
+  })
+
+  it('normalises land input once and chooses gait from intent', () => {
+    expect(resolveScaleEncounterLandInputIntent(0, 0)).toEqual({
+      motion: 'idle',
+      radial: 0,
+      speedMetersPerSecond: 0,
+      tangential: 0,
+    })
+    expect(resolveScaleEncounterLandInputIntent(1, 0)).toEqual({
+      motion: 'walk',
+      radial: 1,
+      speedMetersPerSecond:
+        SCALE_ENCOUNTER_LAND_WALK_SPEED_METERS_PER_SECOND,
+      tangential: 0,
+    })
+    const diagonal = resolveScaleEncounterLandInputIntent(1, 1)
+    expect(diagonal.motion).toBe('run')
+    expect(diagonal.speedMetersPerSecond).toBe(
+      SCALE_ENCOUNTER_LAND_RUN_SPEED_METERS_PER_SECOND,
+    )
+    expect(diagonal.radial).toBeCloseTo(Math.SQRT1_2, 12)
+    expect(diagonal.tangential).toBeCloseTo(Math.SQRT1_2, 12)
+    expect(Math.hypot(diagonal.radial, diagonal.tangential)).toBeCloseTo(
+      1,
+      12,
+    )
   })
 })

--- a/tests/viewer.test.ts
+++ b/tests/viewer.test.ts
@@ -38,6 +38,7 @@ import {
   computeModelTransitionFrame,
   computeModelBounds,
   createCameraRelativeLightingPose,
+  minimumScaleEncounterDistanceForProfile,
   readModelResponseBuffer,
   requestModelResponse,
   resetStagedModelPose,
@@ -52,6 +53,8 @@ import {
   createScaleEncounterPlacement,
   positionOnScaleEncounterRail,
   scaleEncounterSubjectLayoutForAspect,
+  type NormalizedScaleEncounterProfile,
+  type ScaleEncounterAnimalId,
   type ScaleEncounterAvatarFactory,
 } from '../src/viewer/scale-encounter'
 
@@ -525,6 +528,309 @@ describe('scale encounter avatar locomotion', () => {
     expect(
       harness.renderer.domElement.dataset.scaleEncounterAvatarMotion,
     ).toBe('idle')
+  })
+
+  it.each([
+    [
+      'ordinary forest animal',
+      'tyrannosaurus-rex',
+      new Vector3(-3.8, 0, -0.8),
+      new Vector3(8.2, 4, 0.8),
+      12.5,
+    ],
+    [
+      'Apatosaurus body-centred rail',
+      'apatosaurus',
+      new Vector3(-8, 0, -1.5),
+      new Vector3(15, 5, 1.5),
+      12,
+    ],
+  ] as const)(
+    'keeps unified world speeds and intent-driven actions on an %s',
+    (_label, animalId, boundsMinimum, boundsMaximum, distance) => {
+      const makeHarness = () => {
+        const harness = createGroundedPovController(
+          1440 / 900,
+          animalId,
+          boundsMinimum,
+          boundsMaximum,
+        )
+        harness.encounter.observerDistance = distance
+        harness.encounter.targetObserverDistance = distance
+        const internals = harness.controller as unknown as {
+          applyScaleEncounterPovPose: () => void
+          updateScaleEncounterAvatarMotion: (deltaSeconds: number) => void
+          updateScaleEncounterDistance: (
+            deltaSeconds: number,
+            now: number,
+          ) => void
+          updateScaleEncounterOrbit: (
+            deltaSeconds: number,
+            now: number,
+          ) => void
+        }
+        internals.applyScaleEncounterPovPose()
+        harness.encounter.avatarPreviousEyePosition.copy(
+          harness.avatarEye.getWorldPosition(new Vector3()),
+        )
+        return { harness, internals }
+      }
+
+      const runForOneSecond = (
+        radial: -1 | 0 | 1,
+        tangential: -1 | 0 | 1,
+      ) => {
+        const { harness, internals } = makeHarness()
+        harness.controller.setScaleEncounterDistanceMotion(radial)
+        harness.controller.setScaleEncounterOrbitMotion(tangential)
+        let pathLength = 0
+        for (let frame = 1; frame <= 60; frame += 1) {
+          const previous = harness.avatarEye.getWorldPosition(new Vector3())
+          internals.updateScaleEncounterDistance(1 / 60, frame * 16)
+          internals.updateScaleEncounterOrbit(1 / 60, frame * 16)
+          internals.updateScaleEncounterAvatarMotion(1 / 60)
+          pathLength += harness.avatarEye
+            .getWorldPosition(new Vector3())
+            .sub(previous)
+            .setY(0)
+            .length()
+        }
+        return { harness, pathLength }
+      }
+
+      const closer = runForOneSecond(1, 0)
+      expect(closer.pathLength).toBeCloseTo(1.4, 4)
+      expect(
+        closer.harness.encounter.avatar.root.userData
+          .scaleEncounterAvatarMotion,
+      ).toBe('walk')
+
+      const farther = runForOneSecond(-1, 0)
+      expect(farther.pathLength).toBeCloseTo(1.4, 4)
+      expect(
+        farther.harness.encounter.avatar.root.userData
+          .scaleEncounterAvatarMotion,
+      ).toBe('walk')
+
+      const orbit = runForOneSecond(0, 1)
+      expect(orbit.pathLength).toBeCloseTo(2.8, 3)
+      expect(
+        orbit.harness.encounter.avatar.root.userData
+          .scaleEncounterAvatarMotion,
+      ).toBe('run')
+
+      const diagonal = runForOneSecond(1, 1)
+      expect(diagonal.pathLength).toBeCloseTo(2.8, 3)
+      expect(
+        diagonal.harness.encounter.avatar.root.userData
+          .scaleEncounterAvatarMotion,
+      ).toBe('run')
+    },
+  )
+
+  it('keeps diagonals locally 45 degrees, cancels idle input and switches gait when one key is released', () => {
+    const harness = createGroundedPovController(1440 / 900)
+    const internals = harness.controller as unknown as {
+      applyScaleEncounterPovPose: () => void
+      updateScaleEncounterAvatarMotion: (deltaSeconds: number) => void
+      updateScaleEncounterDistance: (
+        deltaSeconds: number,
+        now: number,
+      ) => void
+      updateScaleEncounterOrbit: (
+        deltaSeconds: number,
+        now: number,
+      ) => void
+    }
+    internals.applyScaleEncounterPovPose()
+    harness.encounter.avatarPreviousEyePosition.copy(
+      harness.avatarEye.getWorldPosition(new Vector3()),
+    )
+    const start = harness.avatarEye.getWorldPosition(new Vector3())
+    const outward = start
+      .clone()
+      .sub(harness.placement.orbitCenter)
+      .setY(0)
+      .normalize()
+    const inward = outward.clone().negate()
+    const clockwiseTangent = new Vector3(outward.z, 0, -outward.x)
+
+    harness.controller.setScaleEncounterDistanceMotion(1)
+    harness.controller.setScaleEncounterOrbitMotion(1)
+    internals.updateScaleEncounterDistance(1 / 120, 8)
+    internals.updateScaleEncounterOrbit(1 / 120, 8)
+    internals.updateScaleEncounterAvatarMotion(1 / 120)
+    const diagonalTravel = harness.avatarEye
+      .getWorldPosition(new Vector3())
+      .sub(start)
+      .setY(0)
+    expect(diagonalTravel.length() * 120).toBeCloseTo(2.8, 3)
+    expect(diagonalTravel.dot(inward) * 120).toBeCloseTo(
+      2.8 * Math.SQRT1_2,
+      2,
+    )
+    expect(diagonalTravel.dot(clockwiseTangent) * 120).toBeCloseTo(
+      2.8 * Math.SQRT1_2,
+      2,
+    )
+
+    harness.controller.setScaleEncounterOrbitMotion(0)
+    internals.updateScaleEncounterDistance(1 / 60, 24)
+    internals.updateScaleEncounterOrbit(1 / 60, 24)
+    internals.updateScaleEncounterAvatarMotion(1 / 60)
+    expect(
+      harness.encounter.avatar.root.userData.scaleEncounterAvatarMotion,
+    ).toBe('walk')
+    expect(
+      Number(
+        harness.encounter.avatar.root.userData
+          .scaleEncounterAvatarTravelSpeed,
+      ),
+    ).toBeCloseTo(1.4, 4)
+
+    harness.controller.setScaleEncounterDistanceMotion(0)
+    const idleStart = harness.avatarEye.getWorldPosition(new Vector3())
+    internals.updateScaleEncounterDistance(1 / 60, 40)
+    internals.updateScaleEncounterOrbit(1 / 60, 40)
+    internals.updateScaleEncounterAvatarMotion(1 / 60)
+    expect(
+      harness.avatarEye
+        .getWorldPosition(new Vector3())
+        .distanceTo(idleStart),
+    ).toBeLessThan(1e-10)
+    expect(
+      harness.encounter.avatar.root.userData.scaleEncounterAvatarMotion,
+    ).toBe('idle')
+  })
+
+  it('integrates the same diagonal destination at low and high frame rates', () => {
+    const simulate = (framesPerSecond: number) => {
+      const harness = createGroundedPovController(1440 / 900)
+      const internals = harness.controller as unknown as {
+        applyScaleEncounterPovPose: () => void
+        updateScaleEncounterDistance: (
+          deltaSeconds: number,
+          now: number,
+        ) => void
+        updateScaleEncounterOrbit: (
+          deltaSeconds: number,
+          now: number,
+        ) => void
+      }
+      internals.applyScaleEncounterPovPose()
+      harness.controller.setScaleEncounterDistanceMotion(-1)
+      harness.controller.setScaleEncounterOrbitMotion(1)
+      for (let frame = 1; frame <= framesPerSecond; frame += 1) {
+        internals.updateScaleEncounterDistance(
+          1 / framesPerSecond,
+          (frame * 1_000) / framesPerSecond,
+        )
+        internals.updateScaleEncounterOrbit(
+          1 / framesPerSecond,
+          (frame * 1_000) / framesPerSecond,
+        )
+      }
+      return harness.avatarEye.getWorldPosition(new Vector3())
+    }
+
+    expect(simulate(15).distanceTo(simulate(120))).toBeLessThan(0.01)
+  })
+
+  it('slides around the Apatosaurus leg boundary, then retreats without a corrective jump', () => {
+    const harness = createGroundedPovController(
+      1440 / 900,
+      'apatosaurus',
+      new Vector3(-8, 0, -1.5),
+      new Vector3(15, 5, 1.5),
+    )
+    harness.encounter.profile = {
+      approach: 'close',
+      gender: 'girl',
+      heightCm: 110,
+      heightMeters: 1.1,
+    }
+    harness.encounter.orbitAngleRadians = Math.PI / 2
+    harness.encounter.targetOrbitAngleRadians = Math.PI / 2
+    const boundaryDistance = minimumScaleEncounterDistanceForProfile(
+      harness.encounter.placement,
+      harness.encounter.definition,
+      harness.encounter.profile,
+      harness.encounter.orbitAngleRadians,
+    )
+    harness.encounter.observerDistance = boundaryDistance
+    harness.encounter.targetObserverDistance = boundaryDistance
+    const internals = harness.controller as unknown as {
+      applyScaleEncounterPovPose: () => void
+      updateScaleEncounterAvatarMotion: (deltaSeconds: number) => void
+      updateScaleEncounterDistance: (
+        deltaSeconds: number,
+        now: number,
+      ) => void
+      updateScaleEncounterOrbit: (
+        deltaSeconds: number,
+        now: number,
+      ) => void
+    }
+    internals.applyScaleEncounterPovPose()
+    harness.encounter.avatarPreviousEyePosition.copy(
+      harness.avatarEye.getWorldPosition(new Vector3()),
+    )
+
+    harness.controller.setScaleEncounterDistanceMotion(1)
+    harness.controller.setScaleEncounterOrbitMotion(1)
+    const startingAngle = harness.encounter.orbitAngleRadians
+    let maximumFrameTravel = 0
+    for (let frame = 1; frame <= 60; frame += 1) {
+      const previous = harness.avatarEye.getWorldPosition(new Vector3())
+      internals.updateScaleEncounterDistance(1 / 60, frame * 16)
+      internals.updateScaleEncounterOrbit(1 / 60, frame * 16)
+      internals.updateScaleEncounterAvatarMotion(1 / 60)
+      const frameTravel = harness.avatarEye
+        .getWorldPosition(new Vector3())
+        .sub(previous)
+        .setY(0)
+        .length()
+      maximumFrameTravel = Math.max(maximumFrameTravel, frameTravel)
+      const minimum = minimumScaleEncounterDistanceForProfile(
+        harness.encounter.placement,
+        harness.encounter.definition,
+        harness.encounter.profile,
+        harness.encounter.orbitAngleRadians,
+      )
+      expect(Number.isFinite(harness.encounter.observerDistance)).toBe(true)
+      expect(harness.encounter.observerDistance).toBeGreaterThanOrEqual(
+        minimum - 1e-5,
+      )
+    }
+    expect(harness.encounter.orbitAngleRadians - startingAngle).toBeGreaterThan(
+      0.2,
+    )
+    expect(maximumFrameTravel).toBeLessThanOrEqual(2.8 / 60 + 1e-5)
+    expect(
+      harness.encounter.avatar.root.userData.scaleEncounterAvatarMotion,
+    ).toBe('run')
+
+    const beforeRetreat = harness.avatarEye
+      .getWorldPosition(new Vector3())
+      .sub(harness.encounter.placement.orbitCenter)
+      .setY(0)
+      .length()
+    harness.controller.setScaleEncounterOrbitMotion(0)
+    harness.controller.setScaleEncounterDistanceMotion(-1)
+    for (let frame = 61; frame <= 120; frame += 1) {
+      internals.updateScaleEncounterDistance(1 / 60, frame * 16)
+      internals.updateScaleEncounterOrbit(1 / 60, frame * 16)
+      internals.updateScaleEncounterAvatarMotion(1 / 60)
+    }
+    const afterRetreat = harness.avatarEye
+      .getWorldPosition(new Vector3())
+      .sub(harness.encounter.placement.orbitCenter)
+      .setY(0)
+      .length()
+    expect(afterRetreat - beforeRetreat).toBeCloseTo(1.4, 4)
+    expect(
+      harness.encounter.avatar.root.userData.scaleEncounterAvatarMotion,
+    ).toBe('walk')
   })
 })
 
@@ -1074,7 +1380,12 @@ function minimumNearPlaneCornerHeight(camera: PerspectiveCamera): number {
   )
 }
 
-function createGroundedPovController(aspect: number): {
+function createGroundedPovController(
+  aspect: number,
+  animalId: ScaleEncounterAnimalId = 'tyrannosaurus-rex',
+  boundsMinimum = new Vector3(-3.8, 0, -0.8),
+  boundsMaximum = new Vector3(8.2, 4, 0.8),
+): {
   readonly avatarEye: Group
   readonly camera: PerspectiveCamera
   readonly container: { clientHeight: number; clientWidth: number }
@@ -1103,6 +1414,8 @@ function createGroundedPovController(aspect: number): {
     orbitAngleRadians: number
     orbitMotionDirection: -1 | 0 | 1
     overviewZoom: number
+    placement: ReturnType<typeof createScaleEncounterPlacement>
+    profile: NormalizedScaleEncounterProfile
     targetObserverDistance: number
     targetOrbitAngleRadians: number
     targetOverviewZoom: number
@@ -1116,11 +1429,11 @@ function createGroundedPovController(aspect: number): {
     readonly setSize: ReturnType<typeof vi.fn>
   }
 } {
-  const definition = SCALE_ENCOUNTER_DEFINITIONS['tyrannosaurus-rex']
+  const definition = SCALE_ENCOUNTER_DEFINITIONS[animalId]
   const placement = createScaleEncounterPlacement(
     definition.id,
-    new Vector3(-3.8, 0, -0.8),
-    new Vector3(8.2, 4, 0.8),
+    boundsMinimum,
+    boundsMaximum,
     0.985,
   )
   const avatarRoot = new Group()
@@ -1179,6 +1492,7 @@ function createGroundedPovController(aspect: number): {
     jumpVelocityMetersPerSecond: 0,
     placement,
     profile: {
+      approach: 'comfortable' as const,
       gender: 'girl' as const,
       heightCm: 100,
       heightMeters: 1,


### PR DESCRIPTION
## 这次解决的问题

- 修复迷惑龙靠近四条腿时出现的不可接近死区、只能左右移动，以及穿透碰撞后向前闪现的问题。
- 修复迷惑龙左右环绕时仍然播放慢走动作的问题。
- 统一所有陆地场景的输入语义和最终世界速度，同时不改动天空、水下控制。

## 实现要点

- 迷惑龙继续使用为长身体设计的身体中心径向轨道；其他陆地动物保留原有观察轨道、初始构图、最近和最远距离、碰撞边界及场景尺度。
- 将陆地输入统一为动物局部极坐标：上下径向移动，左右切向环绕；相反方向抵消。
- 统一步行速度为 1.4 m/s、跑步速度为 2.8 m/s，并把轨道参数反算为真实世界位移，避免速度随动物尺度、轨道半径或参数映射改变。
- 斜向输入先归一化再整体应用 2.8 m/s 的跑步速度，避免对角线出现 sqrt(2) 倍加速，并保持局部 45 度方向。
- 动作选择由有效输入意图决定：径向为 walk，存在切向输入即为 run，无输入为 idle；人物朝向仍跟随最终实际移动方向。
- 碰撞通过小步扫掠和安全投影限制最终位置。接近边界时移除向内分量并保留可滑动分量，向外后退始终允许，避免穿透后回推造成跳变。

## 回归范围

- 普通森林陆地动物与迷惑龙的前后、左右、斜向速度及动作状态。
- 不同轨道半径、动物尺度和低高帧率下的世界速度一致性。
- 相反方向抵消、斜向松开单键后的动作切换及 idle 状态。
- 迷惑龙四腿附近的接近边界、沿边界滑动、正常后退及无瞬移。
- 其他陆地动物原有轨道和构图不变；天空、水下行为不变。

## 验证

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`：68 个测试文件、681 项测试通过
- `npm run build:e2e`
- 4190 实机预览：迷惑龙左右环绕为 `run / Run_Forest / 2.800 m/s`，前后移动为 `walk / Walk_Forest / 1.400 m/s`