### PR TITLE
Stabilize prerender document test timeout

### DIFF
--- a/tests/prerender-document.test.ts
+++ b/tests/prerender-document.test.ts
@@ -308,5 +308,5 @@ describe('localized museum prerender document', () => {
     } finally {
       await rm(outputDirectory, { recursive: true })
     }
-  })
+  }, 15_000)
 })


### PR DESCRIPTION
## Summary

- raise the 36-page prerender integration test timeout from 5 seconds to 15 seconds
- keep production code unchanged

## Context

The same test passed locally and in the original PR, then exceeded 5 seconds twice on the GitHub runner after the repository-history cleanup. Local lint, typecheck, and the targeted test pass.