### PR TITLE
Fix language menu clipping on narrow screens

### DIFF
--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -103,6 +103,24 @@ async function expectUnmistakableSelectedLanguage(menu: Locator): Promise<void> 
   }
 }
 
+async function expectMenuInsideViewport(page: Page, menu: Locator): Promise<void> {
+  const layout = await menu.evaluate((element) => {
+    const box = element.getBoundingClientRect()
+    return {
+      bottom: box.bottom,
+      left: box.left,
+      right: box.right,
+      top: box.top,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+    }
+  })
+  expect(layout.left).toBeGreaterThanOrEqual(11)
+  expect(layout.top).toBeGreaterThanOrEqual(11)
+  expect(layout.right).toBeLessThanOrEqual(layout.viewportWidth - 11)
+  expect(layout.bottom).toBeLessThanOrEqual(layout.viewportHeight - 11)
+}
+
 async function expectReadableEnglishStoryLayout(
   page: Page,
   viewport: (typeof responsiveStoryViewports)[number],
@@ -754,11 +772,11 @@ test('keeps an open drawer and model focus mode during an in-place language swit
     .click()
   await page.keyboard.press('Escape')
   await expect(chineseGuide).toBeVisible()
-  await expect(chineseGuide.getByRole('menu')).toHaveCount(0)
+  await expect(page.getByRole('menu')).toHaveCount(0)
   await chineseGuide
     .getByRole('button', { name: '切换语言，当前简体中文' })
     .click()
-  await chineseGuide.getByRole('menuitemradio', { name: 'English' }).click()
+  await page.getByRole('menuitemradio', { name: 'English' }).click()
   const englishGuide = page.getByRole('dialog', { name: 'Guide for grown-ups' })
   await expect(englishGuide).toBeVisible()
   await expect(englishGuide.getByText('When it lived', { exact: true })).toBeVisible()
@@ -818,14 +836,25 @@ test('makes the selected language unmistakable in both museum sheets', async ({
     expect(response?.ok()).toBe(true)
     await waitForMuseumShell(page, '剑龙')
 
+    await page
+      .getByRole('button', { name: '切换语言，当前简体中文' })
+      .click()
+    await expectMenuInsideViewport(
+      page,
+      page.getByRole('menu', { name: '选择界面语言' }),
+    )
+    await page.keyboard.press('Escape')
+
     await page.getByRole('button', { name: '打开全馆图鉴' }).click()
     const collection = page.getByRole('dialog', { name: '全馆图鉴' })
     await collection
       .getByRole('button', { name: '切换语言，当前简体中文' })
       .click()
+    const collectionMenu = page.getByRole('menu', { name: '选择界面语言' })
     await expectUnmistakableSelectedLanguage(
-      collection.getByRole('menu', { name: '选择界面语言' }),
+      collectionMenu,
     )
+    await expectMenuInsideViewport(page, collectionMenu)
     await page.keyboard.press('Escape')
     await collection.getByRole('button', { name: '关闭全馆图鉴' }).click()
 
@@ -834,9 +863,9 @@ test('makes the selected language unmistakable in both museum sheets', async ({
     await guide
       .getByRole('button', { name: '切换语言，当前简体中文' })
       .click()
-    await expectUnmistakableSelectedLanguage(
-      guide.getByRole('menu', { name: '选择界面语言' }),
-    )
+    const guideMenu = page.getByRole('menu', { name: '选择界面语言' })
+    await expectUnmistakableSelectedLanguage(guideMenu)
+    await expectMenuInsideViewport(page, guideMenu)
     expect(await page.evaluate(() => window.devicePixelRatio)).toBe(2)
   } finally {
     await context.close()

--- a/src/components/LanguageMenu.tsx
+++ b/src/components/LanguageMenu.tsx
@@ -1,19 +1,38 @@
 import { Check, Languages } from 'lucide-react'
 import {
+  useCallback,
   useEffect,
+  useId,
+  useLayoutEffect,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from 'react'
+import { createPortal } from 'react-dom'
 import { useI18n } from '../i18n/I18nProvider'
 import { systemLocale, type LocalePreference } from '../i18n/locale'
 
 const choices: readonly LocalePreference[] = ['system', 'zh-CN', 'en']
+const popoverGap = 9
+const viewportMargin = 12
+const preferredPopoverWidth = 304
+
+interface PopoverPosition {
+  readonly accentSoft: string
+  readonly left: number
+  readonly top: number
+  readonly width: number
+}
 
 export function LanguageMenu() {
   const { locale, messages, preference, setPreference } = useI18n()
   const [open, setOpen] = useState(false)
+  const [popoverPosition, setPopoverPosition] =
+    useState<PopoverPosition | null>(null)
+  const menuId = useId()
+  const menuRef = useRef<HTMLDivElement>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const itemRefs = useRef(new Map<LocalePreference, HTMLButtonElement>())
@@ -50,6 +69,7 @@ export function LanguageMenu() {
 
   const close = (restoreFocus = false) => {
     setOpen(false)
+    setPopoverPosition(null)
     if (restoreFocus) {
       queueMicrotask(() => triggerRef.current?.focus())
     }
@@ -60,12 +80,101 @@ export function LanguageMenu() {
     queueMicrotask(() => itemRefs.current.get(choice)?.focus())
   }
 
+  const positionPopover = useCallback(() => {
+    const trigger = triggerRef.current
+    const menu = menuRef.current
+    if (!trigger || !menu) {
+      return
+    }
+
+    const viewport = window.visualViewport
+    const viewportLeft = viewport?.offsetLeft ?? 0
+    const viewportTop = viewport?.offsetTop ?? 0
+    const viewportWidth = viewport?.width ?? window.innerWidth
+    const viewportHeight = viewport?.height ?? window.innerHeight
+    const viewportRight = viewportLeft + viewportWidth
+    const viewportBottom = viewportTop + viewportHeight
+    const triggerBox = trigger.getBoundingClientRect()
+    const menuHeight = menu.getBoundingClientRect().height
+    const width = Math.min(
+      preferredPopoverWidth,
+      Math.max(0, viewportWidth - viewportMargin * 2),
+    )
+    const minLeft = viewportLeft + viewportMargin
+    const maxLeft = Math.max(minLeft, viewportRight - viewportMargin - width)
+    const left = Math.min(
+      Math.max(triggerBox.right - width, minLeft),
+      maxLeft,
+    )
+    const below = triggerBox.bottom + popoverGap
+    const above = triggerBox.top - popoverGap - menuHeight
+    const availableBelow = viewportBottom - viewportMargin - below
+    const availableAbove =
+      triggerBox.top - popoverGap - (viewportTop + viewportMargin)
+    const preferredTop =
+      menuHeight <= availableBelow || availableBelow >= availableAbove
+        ? below
+        : above
+    const maxTop = Math.max(
+      viewportTop + viewportMargin,
+      viewportBottom - viewportMargin - menuHeight,
+    )
+    const top = Math.min(
+      Math.max(preferredTop, viewportTop + viewportMargin),
+      maxTop,
+    )
+    const accentSoft = getComputedStyle(trigger).getPropertyValue(
+      '--animal-accent-soft',
+    )
+
+    setPopoverPosition((current) => {
+      const next = { accentSoft, left, top, width }
+      return current?.accentSoft === next.accentSoft &&
+        current.left === next.left &&
+        current.top === next.top &&
+        current.width === next.width
+        ? current
+        : next
+    })
+  }, [])
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return
+    }
+
+    positionPopover()
+    const viewport = window.visualViewport
+    const observer =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(positionPopover)
+    if (triggerRef.current) observer?.observe(triggerRef.current)
+    if (menuRef.current) observer?.observe(menuRef.current)
+    window.addEventListener('resize', positionPopover)
+    window.addEventListener('scroll', positionPopover, true)
+    viewport?.addEventListener('resize', positionPopover)
+    viewport?.addEventListener('scroll', positionPopover)
+
+    return () => {
+      observer?.disconnect()
+      window.removeEventListener('resize', positionPopover)
+      window.removeEventListener('scroll', positionPopover, true)
+      viewport?.removeEventListener('resize', positionPopover)
+      viewport?.removeEventListener('scroll', positionPopover)
+    }
+  }, [open, positionPopover])
+
   useEffect(() => {
     if (!open) {
       return
     }
     const handlePointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) {
+      const target = event.target as Node
+      if (
+        !rootRef.current?.contains(target) &&
+        !menuRef.current?.contains(target)
+      ) {
         close()
       }
     }
@@ -86,7 +195,22 @@ export function LanguageMenu() {
       return
     }
     if (event.key === 'Tab') {
-      queueMicrotask(() => close())
+      event.preventDefault()
+      const trigger = triggerRef.current
+      const focusTarget = event.shiftKey
+        ? trigger
+        : Array.from(
+            document.querySelectorAll<HTMLElement>(
+              'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+            ),
+          ).find(
+            (element, index, elements) =>
+              index > elements.indexOf(trigger!) &&
+              !menuRef.current?.contains(element) &&
+              !element.closest('[inert]'),
+          )
+      close()
+      queueMicrotask(() => (focusTarget ?? trigger)?.focus())
       return
     }
     if (event.key === 'Home' || event.key === 'End') {
@@ -111,6 +235,7 @@ export function LanguageMenu() {
   return (
     <div className="language-menu" ref={rootRef}>
       <button
+        aria-controls={open ? menuId : undefined}
         aria-expanded={open}
         aria-haspopup="menu"
         aria-label={messages.language.buttonLabel}
@@ -133,42 +258,57 @@ export function LanguageMenu() {
         <Languages aria-hidden="true" size={20} strokeWidth={2.1} />
         <span>{locale === 'zh-CN' ? '中' : 'EN'}</span>
       </button>
-      {open ? (
-        <div
-          aria-label={messages.language.menuLabel}
-          className="language-menu__popover"
-          onKeyDown={handleMenuKeyDown}
-          role="menu"
-        >
-          {choices.map((choice) => (
-            <button
-              aria-checked={preference === choice}
-              className="language-menu__choice"
-              key={choice}
-              onClick={() => {
-                setPreference(choice)
-                close(true)
-              }}
-              ref={(element) => {
-                if (element) itemRefs.current.set(choice, element)
-                else itemRefs.current.delete(choice)
-              }}
-              role="menuitemradio"
-              tabIndex={-1}
-              type="button"
+      {open
+        ? createPortal(
+            <div
+              aria-label={messages.language.menuLabel}
+              className="language-menu__popover"
+              data-positioned={popoverPosition !== null}
+              id={menuId}
+              onKeyDown={handleMenuKeyDown}
+              ref={menuRef}
+              role="menu"
+              style={
+                {
+                  '--animal-accent-soft':
+                    popoverPosition?.accentSoft || undefined,
+                  left: popoverPosition?.left ?? 0,
+                  top: popoverPosition?.top ?? 0,
+                  width: popoverPosition?.width ?? preferredPopoverWidth,
+                } as CSSProperties
+              }
             >
-              <span aria-hidden="true" className="language-menu__radio" />
-              <span>{labelFor(choice)}</span>
-              <span
-                aria-hidden="true"
-                className="language-menu__selected-mark"
-              >
-                <Check size={17} strokeWidth={3} />
-              </span>
-            </button>
-          ))}
-        </div>
-      ) : null}
+              {choices.map((choice) => (
+                <button
+                  aria-checked={preference === choice}
+                  className="language-menu__choice"
+                  key={choice}
+                  onClick={() => {
+                    setPreference(choice)
+                    close(true)
+                  }}
+                  ref={(element) => {
+                    if (element) itemRefs.current.set(choice, element)
+                    else itemRefs.current.delete(choice)
+                  }}
+                  role="menuitemradio"
+                  tabIndex={-1}
+                  type="button"
+                >
+                  <span aria-hidden="true" className="language-menu__radio" />
+                  <span>{labelFor(choice)}</span>
+                  <span
+                    aria-hidden="true"
+                    className="language-menu__selected-mark"
+                  >
+                    <Check size={17} strokeWidth={3} />
+                  </span>
+                </button>
+              ))}
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4846,13 +4846,9 @@ html[data-locale="en"] .collection-card__copy strong {
 }
 
 .language-menu__popover {
-  position: absolute;
-  z-index: 60;
-  top: calc(100% + 9px);
-  right: 0;
+  position: fixed;
+  z-index: 100;
   display: grid;
-  width: max-content;
-  min-width: 190px;
   gap: 3px;
   padding: 7px;
   border: 1px solid rgb(48 77 62 / 13%);
@@ -4860,6 +4856,10 @@ html[data-locale="en"] .collection-card__copy strong {
   background: rgb(255 253 247 / 97%);
   box-shadow: 0 18px 45px rgb(28 46 37 / 22%);
   backdrop-filter: blur(16px);
+}
+
+.language-menu__popover[data-positioned="false"] {
+  visibility: hidden;
 }
 
 .language-menu__choice {
@@ -4875,6 +4875,12 @@ html[data-locale="en"] .collection-card__copy strong {
   cursor: pointer;
   font-weight: 760;
   text-align: left;
+}
+
+.language-menu__choice > :nth-child(2) {
+  min-width: 0;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .language-menu__choice [lang="zh-CN"] {
@@ -5012,10 +5018,6 @@ html[data-locale="en"] .collection-card__copy strong {
     border-radius: 13px;
   }
 
-  .language-menu__popover {
-    top: 0;
-    right: calc(100% + 7px);
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -919,7 +919,7 @@ describe('App', () => {
       }),
     )
     await user.click(
-      within(chineseDialog).getByRole('menuitemradio', { name: 'English' }),
+      screen.getByRole('menuitemradio', { name: 'English' }),
     )
 
     const englishDialog = screen.getByRole('dialog', {

--- a/tests/language-menu.test.tsx
+++ b/tests/language-menu.test.tsx
@@ -69,6 +69,39 @@ describe('LanguageMenu', () => {
     expect(trigger).toHaveFocus()
   })
 
+  it('keeps the portalled menu inside a narrow viewport', async () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(320)
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(568)
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+      function (this: HTMLElement) {
+        if (this.classList.contains('language-menu__trigger')) {
+          return DOMRect.fromRect({ x: 198, y: 20, width: 52, height: 52 })
+        }
+        if (this.classList.contains('language-menu__popover')) {
+          return DOMRect.fromRect({ width: 296, height: 160 })
+        }
+        return DOMRect.fromRect()
+      },
+    )
+    const user = userEvent.setup()
+    renderLanguageMenu()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Change language, current English',
+      }),
+    )
+
+    const menu = screen.getByRole('menu', {
+      name: 'Choose interface language',
+    })
+    await waitFor(() => expect(menu).toHaveAttribute('data-positioned', 'true'))
+    expect(menu.parentElement).toBe(document.body)
+    expect(menu.style.left).toBe('12px')
+    expect(menu.style.top).toBe('81px')
+    expect(menu.style.width).toBe('296px')
+  })
+
   it('closes on Tab and Shift+Tab while preserving the browser focus order', async () => {
     window.localStorage.setItem(localePreferenceStorageKey, 'zh-CN')
     const user = userEvent.setup()
@@ -105,7 +138,7 @@ describe('LanguageMenu', () => {
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
     expect(afterMenu).toHaveFocus()
-    expect(tabDefaultPrevented).toEqual([false])
+    expect(tabDefaultPrevented).toEqual([true])
 
     trigger.focus()
     await user.keyboard('{ArrowUp}')
@@ -117,7 +150,7 @@ describe('LanguageMenu', () => {
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument()
     expect(trigger).toHaveFocus()
-    expect(tabDefaultPrevented).toEqual([false, false])
+    expect(tabDefaultPrevented).toEqual([true, true])
   })
 
   it('contains Escape so parent keyboard handlers do not close another layer', async () => {


### PR DESCRIPTION
## Summary
- render the language menu popover outside clipping drawer and sheet containers
- keep the popover within the visual viewport, including resize, scroll, and mobile zoom changes
- preserve keyboard navigation and focus order after portalling the menu
- add narrow-viewport unit and end-to-end regression coverage

## Validation
- npm test -- --run tests/language-menu.test.tsx
- npm run typecheck
- npm run lint
- npm run build
- headed browser review at 414 x 896 in Chinese and English