### PR TITLE
fix: refine drawer scrollbars

### DIFF
--- a/src/components/AboutDrawer.tsx
+++ b/src/components/AboutDrawer.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../i18n/I18nProvider'
 import { IconButton } from './IconButton'
 import { LanguageMenu } from './LanguageMenu'
 import { OfficialLinks } from './OfficialLinks'
+import { TransientScrollbar } from './TransientScrollbar'
 import { useTransientScrollbar } from './useTransientScrollbar'
 
 interface AboutDrawerProps {
@@ -28,7 +29,8 @@ export function AboutDrawer({
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const drawerRef = useRef<HTMLElement>(null)
   const titleId = useId()
-  const { handleScroll, isScrolling } = useTransientScrollbar()
+  const { handleScroll, isScrolling, metrics, scrollRef } =
+    useTransientScrollbar(open)
 
   useEffect(() => {
     if (!open) {
@@ -101,12 +103,13 @@ export function AboutDrawer({
             />
           </div>
         </header>
-        <div
-          className="drawer-scroll museum-scrollbar about-drawer__scroll"
-          data-scrolling={isScrolling}
-          onScroll={handleScroll}
-        >
-          <div className="about-drawer__body">
+        <div className="drawer-scroll-shell">
+          <div
+            className="drawer-scroll museum-scrollbar about-drawer__scroll"
+            onScroll={handleScroll}
+            ref={scrollRef}
+          >
+            <div className="about-drawer__body">
             <section className="about-story">
               <h3>{messages.about.heading}</h3>
               {messages.about.paragraphs.map((paragraph) => (
@@ -135,7 +138,9 @@ export function AboutDrawer({
                 <ExternalLink aria-hidden="true" size={16} strokeWidth={2} />
               </a>
             </div>
+            </div>
           </div>
+          <TransientScrollbar isScrolling={isScrolling} metrics={metrics} />
         </div>
       </section>
     </div>

--- a/src/components/AboutDrawer.tsx
+++ b/src/components/AboutDrawer.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../i18n/I18nProvider'
 import { IconButton } from './IconButton'
 import { LanguageMenu } from './LanguageMenu'
 import { OfficialLinks } from './OfficialLinks'
+import { useTransientScrollbar } from './useTransientScrollbar'
 
 interface AboutDrawerProps {
   readonly onClose: () => void
@@ -27,6 +28,7 @@ export function AboutDrawer({
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const drawerRef = useRef<HTMLElement>(null)
   const titleId = useId()
+  const { handleScroll, isScrolling } = useTransientScrollbar()
 
   useEffect(() => {
     if (!open) {
@@ -99,7 +101,11 @@ export function AboutDrawer({
             />
           </div>
         </header>
-        <div className="drawer-scroll about-drawer__scroll">
+        <div
+          className="drawer-scroll museum-scrollbar about-drawer__scroll"
+          data-scrolling={isScrolling}
+          onScroll={handleScroll}
+        >
           <div className="about-drawer__body">
             <section className="about-story">
               <h3>{messages.about.heading}</h3>

--- a/src/components/ParentDrawer.tsx
+++ b/src/components/ParentDrawer.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../i18n/I18nProvider'
 import { IconButton } from './IconButton'
 import { LanguageMenu } from './LanguageMenu'
 import { OfficialLinks } from './OfficialLinks'
+import { TransientScrollbar } from './TransientScrollbar'
 import { useTransientScrollbar } from './useTransientScrollbar'
 
 export interface ParentReviewFacts {
@@ -77,12 +78,12 @@ export function ParentDrawer({
   const { locale, messages } = useI18n()
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const drawerRef = useRef<HTMLElement>(null)
-  const scrollRef = useRef<HTMLDivElement>(null)
   const [showScrollCue, setShowScrollCue] = useState(false)
   const scrollHintId = useId()
   const titleId = useId()
   const review = showReviewDetails ? facts.review : undefined
-  const { handleScroll, isScrolling } = useTransientScrollbar()
+  const { handleScroll, isScrolling, metrics, scrollRef } =
+    useTransientScrollbar(open)
 
   const updateScrollCue = useCallback(() => {
     const scroll = scrollRef.current
@@ -93,7 +94,7 @@ export function ParentDrawer({
     const remaining =
       scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight
     setShowScrollCue(scroll.scrollHeight > scroll.clientHeight + 2 && remaining > 4)
-  }, [])
+  }, [scrollRef])
 
   useEffect(() => {
     if (!open) {
@@ -157,7 +158,7 @@ export function ParentDrawer({
       window.removeEventListener('resize', updateScrollCue)
       observer?.disconnect()
     }
-  }, [facts, open, updateScrollCue])
+  }, [facts, open, scrollRef, updateScrollCue])
 
   return (
     <div className="drawer-layer" hidden={!open}>
@@ -194,14 +195,14 @@ export function ParentDrawer({
             />
           </div>
         </header>
-        <div
-          aria-describedby={showScrollCue ? scrollHintId : undefined}
-          className="drawer-scroll museum-scrollbar"
-          data-scrolling={isScrolling}
-          onScroll={handleScroll}
-          ref={scrollRef}
-        >
-          <div>
+        <div className="drawer-scroll-shell">
+          <div
+            aria-describedby={showScrollCue ? scrollHintId : undefined}
+            className="drawer-scroll museum-scrollbar"
+            onScroll={handleScroll}
+            ref={scrollRef}
+          >
+            <div>
             <dl className="fact-grid">
               <div>
                 <dt>{messages.parent.period}</dt>
@@ -343,8 +344,10 @@ export function ParentDrawer({
                 </div>
               </div>
             </details>
-            <OfficialLinks compact />
+              <OfficialLinks compact />
+            </div>
           </div>
+          <TransientScrollbar isScrolling={isScrolling} metrics={metrics} />
         </div>
         <p className="sr-only" id={scrollHintId}>
           {messages.parent.moreHint}

--- a/src/components/ParentDrawer.tsx
+++ b/src/components/ParentDrawer.tsx
@@ -194,7 +194,7 @@ export function ParentDrawer({
         </header>
         <div
           aria-describedby={showScrollCue ? scrollHintId : undefined}
-          className="drawer-scroll"
+          className="drawer-scroll parent-drawer__scroll"
           ref={scrollRef}
         >
           <div>

--- a/src/components/ParentDrawer.tsx
+++ b/src/components/ParentDrawer.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '../i18n/I18nProvider'
 import { IconButton } from './IconButton'
 import { LanguageMenu } from './LanguageMenu'
 import { OfficialLinks } from './OfficialLinks'
+import { useTransientScrollbar } from './useTransientScrollbar'
 
 export interface ParentReviewFacts {
   readonly badge: string
@@ -81,6 +82,7 @@ export function ParentDrawer({
   const scrollHintId = useId()
   const titleId = useId()
   const review = showReviewDetails ? facts.review : undefined
+  const { handleScroll, isScrolling } = useTransientScrollbar()
 
   const updateScrollCue = useCallback(() => {
     const scroll = scrollRef.current
@@ -194,7 +196,9 @@ export function ParentDrawer({
         </header>
         <div
           aria-describedby={showScrollCue ? scrollHintId : undefined}
-          className="drawer-scroll parent-drawer__scroll"
+          className="drawer-scroll museum-scrollbar"
+          data-scrolling={isScrolling}
+          onScroll={handleScroll}
           ref={scrollRef}
         >
           <div>

--- a/src/components/TransientScrollbar.tsx
+++ b/src/components/TransientScrollbar.tsx
@@ -1,0 +1,34 @@
+import type { CSSProperties } from 'react'
+import type { ScrollbarMetrics } from './useTransientScrollbar'
+
+interface ScrollbarVisualStyle extends CSSProperties {
+  '--museum-scrollbar-thumb-offset': string
+  '--museum-scrollbar-thumb-size': string
+}
+
+interface TransientScrollbarProps {
+  readonly isScrolling: boolean
+  readonly metrics: ScrollbarMetrics
+}
+
+export function TransientScrollbar({
+  isScrolling,
+  metrics,
+}: TransientScrollbarProps) {
+  const style: ScrollbarVisualStyle = {
+    '--museum-scrollbar-thumb-offset': `${metrics.thumbOffset}px`,
+    '--museum-scrollbar-thumb-size': `${metrics.thumbSize}px`,
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className="museum-scrollbar-visual"
+      data-scrollable={metrics.isScrollable}
+      data-visible={metrics.isScrollable && isScrolling}
+      style={style}
+    >
+      <span />
+    </div>
+  )
+}

--- a/src/components/useTransientScrollbar.ts
+++ b/src/components/useTransientScrollbar.ts
@@ -1,21 +1,106 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type UIEvent } from 'react'
 
-const SCROLLBAR_IDLE_DELAY_MS = 700
+const SCROLLBAR_IDLE_DELAY_MS = 480
+const SCROLLBAR_TRACK_INSET_PX = 4
+const SCROLLBAR_MIN_THUMB_PX = 36
 
-export function useTransientScrollbar() {
+export interface ScrollbarMetrics {
+  readonly isScrollable: boolean
+  readonly thumbOffset: number
+  readonly thumbSize: number
+}
+
+const initialMetrics: ScrollbarMetrics = {
+  isScrollable: false,
+  thumbOffset: 0,
+  thumbSize: SCROLLBAR_MIN_THUMB_PX,
+}
+
+function metricsAreEqual(left: ScrollbarMetrics, right: ScrollbarMetrics) {
+  return (
+    left.isScrollable === right.isScrollable &&
+    left.thumbOffset === right.thumbOffset &&
+    left.thumbSize === right.thumbSize
+  )
+}
+
+export function useTransientScrollbar(open = true) {
   const hideTimerRef = useRef<number | null>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
   const [isScrolling, setIsScrolling] = useState(false)
+  const [metrics, setMetrics] = useState<ScrollbarMetrics>(initialMetrics)
 
-  const handleScroll = useCallback(() => {
-    setIsScrolling(true)
-    if (hideTimerRef.current !== null) {
-      window.clearTimeout(hideTimerRef.current)
+  const updateMetrics = useCallback((element = scrollRef.current) => {
+    if (!element) {
+      return
     }
-    hideTimerRef.current = window.setTimeout(() => {
-      hideTimerRef.current = null
-      setIsScrolling(false)
-    }, SCROLLBAR_IDLE_DELAY_MS)
+    const trackSize = Math.max(
+      0,
+      element.clientHeight - SCROLLBAR_TRACK_INSET_PX * 2,
+    )
+    const scrollRange = Math.max(0, element.scrollHeight - element.clientHeight)
+    const isScrollable = scrollRange > 2
+    const thumbSize = isScrollable
+      ? Math.max(
+          SCROLLBAR_MIN_THUMB_PX,
+          Math.round((element.clientHeight / element.scrollHeight) * trackSize),
+        )
+      : trackSize
+    const thumbRange = Math.max(0, trackSize - thumbSize)
+    const thumbOffset =
+      scrollRange === 0
+        ? 0
+        : Math.round((element.scrollTop / scrollRange) * thumbRange)
+    const nextMetrics = { isScrollable, thumbOffset, thumbSize }
+
+    setMetrics((currentMetrics) =>
+      metricsAreEqual(currentMetrics, nextMetrics)
+        ? currentMetrics
+        : nextMetrics,
+    )
   }, [])
+
+  const handleScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      updateMetrics(event.currentTarget)
+      setIsScrolling(true)
+      if (hideTimerRef.current !== null) {
+        window.clearTimeout(hideTimerRef.current)
+      }
+      hideTimerRef.current = window.setTimeout(() => {
+        hideTimerRef.current = null
+        setIsScrolling(false)
+      }, SCROLLBAR_IDLE_DELAY_MS)
+    },
+    [updateMetrics],
+  )
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    const scroll = scrollRef.current
+    if (!scroll) {
+      return
+    }
+    const handleResize = () => updateMetrics(scroll)
+    const observer =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(handleResize)
+
+    updateMetrics(scroll)
+    observer?.observe(scroll)
+    if (scroll.firstElementChild) {
+      observer?.observe(scroll.firstElementChild)
+    }
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      observer?.disconnect()
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [open, updateMetrics])
 
   useEffect(
     () => () => {
@@ -26,5 +111,5 @@ export function useTransientScrollbar() {
     [],
   )
 
-  return { handleScroll, isScrolling }
+  return { handleScroll, isScrolling, metrics, scrollRef }
 }

--- a/src/components/useTransientScrollbar.ts
+++ b/src/components/useTransientScrollbar.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const SCROLLBAR_IDLE_DELAY_MS = 700
+
+export function useTransientScrollbar() {
+  const hideTimerRef = useRef<number | null>(null)
+  const [isScrolling, setIsScrolling] = useState(false)
+
+  const handleScroll = useCallback(() => {
+    setIsScrolling(true)
+    if (hideTimerRef.current !== null) {
+      window.clearTimeout(hideTimerRef.current)
+    }
+    hideTimerRef.current = window.setTimeout(() => {
+      hideTimerRef.current = null
+      setIsScrolling(false)
+    }, SCROLLBAR_IDLE_DELAY_MS)
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (hideTimerRef.current !== null) {
+        window.clearTimeout(hideTimerRef.current)
+      }
+    },
+    [],
+  )
+
+  return { handleScroll, isScrolling }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1936,67 +1936,76 @@ a:focus-visible {
 }
 
 .drawer-scroll {
+  height: 100%;
   overflow-y: auto;
   overscroll-behavior: contain;
   padding: 10px 26px max(64px, env(safe-area-inset-bottom));
   scrollbar-gutter: stable;
 }
 
-.museum-scrollbar {
-  --museum-scrollbar-thumb: color-mix(
-    in srgb,
-    var(--animal-accent, var(--leaf)) 58%,
-    var(--leaf)
-  );
-  --museum-scrollbar-thumb-hover: color-mix(
-    in srgb,
-    var(--animal-accent, var(--leaf)) 76%,
-    var(--leaf)
-  );
-  --museum-scrollbar-track: color-mix(
-    in srgb,
-    var(--canvas-warm) 62%,
-    transparent
-  );
-  scrollbar-color: transparent transparent;
-  scrollbar-width: thin;
+.drawer-scroll-shell {
+  position: relative;
+  min-height: 0;
+  overflow: hidden;
 }
 
-.museum-scrollbar[data-scrolling="true"],
-.museum-scrollbar:hover {
-  scrollbar-color: var(--museum-scrollbar-thumb) var(--museum-scrollbar-track);
+.museum-scrollbar {
+  scrollbar-color: transparent transparent;
+  scrollbar-width: thin;
 }
 
 .museum-scrollbar::-webkit-scrollbar {
   width: 8px;
 }
 
-.museum-scrollbar::-webkit-scrollbar-track {
-  border-radius: 999px;
-  background-color: transparent;
-  transition: background-color 180ms ease;
-}
-
+.museum-scrollbar::-webkit-scrollbar-track,
 .museum-scrollbar::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
   background-color: transparent;
-  background-clip: padding-box;
-  transition: background-color 180ms ease;
 }
 
-.museum-scrollbar[data-scrolling="true"]::-webkit-scrollbar-track,
-.museum-scrollbar:hover::-webkit-scrollbar-track {
-  background-color: var(--museum-scrollbar-track);
+.museum-scrollbar-visual {
+  position: absolute;
+  z-index: 5;
+  top: 4px;
+  right: 0;
+  bottom: 4px;
+  width: 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--canvas-warm) 62%, transparent);
+  opacity: 0;
+  pointer-events: none;
+  transform: scaleX(0.72);
+  transform-origin: right center;
+  transition:
+    opacity 360ms cubic-bezier(0.2, 0.8, 0.2, 1) 80ms,
+    transform 360ms cubic-bezier(0.2, 0.8, 0.2, 1) 80ms;
 }
 
-.museum-scrollbar[data-scrolling="true"]::-webkit-scrollbar-thumb,
-.museum-scrollbar:hover::-webkit-scrollbar-thumb {
-  background-color: var(--museum-scrollbar-thumb);
+.museum-scrollbar-visual > span {
+  position: absolute;
+  top: 0;
+  right: 2px;
+  width: 4px;
+  height: var(--museum-scrollbar-thumb-size);
+  border-radius: 999px;
+  background: color-mix(
+    in srgb,
+    var(--animal-accent, var(--leaf)) 58%,
+    var(--leaf)
+  );
+  transform: translate3d(0, var(--museum-scrollbar-thumb-offset), 0);
+  transition:
+    height 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    transform 90ms linear;
 }
 
-.museum-scrollbar::-webkit-scrollbar-thumb:hover {
-  background-color: var(--museum-scrollbar-thumb-hover);
+.museum-scrollbar-visual[data-visible="true"],
+.drawer-scroll-shell:hover
+  .museum-scrollbar-visual[data-scrollable="true"] {
+  opacity: 1;
+  transform: scaleX(1);
+  transition-delay: 0ms;
+  transition-duration: 150ms;
 }
 
 .fact-grid {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1942,34 +1942,61 @@ a:focus-visible {
   scrollbar-gutter: stable;
 }
 
-.parent-drawer__scroll {
-  scrollbar-color:
-    color-mix(in srgb, var(--animal-accent, var(--leaf)) 58%, var(--leaf))
-    color-mix(in srgb, var(--canvas-warm) 62%, transparent);
+.museum-scrollbar {
+  --museum-scrollbar-thumb: color-mix(
+    in srgb,
+    var(--animal-accent, var(--leaf)) 58%,
+    var(--leaf)
+  );
+  --museum-scrollbar-thumb-hover: color-mix(
+    in srgb,
+    var(--animal-accent, var(--leaf)) 76%,
+    var(--leaf)
+  );
+  --museum-scrollbar-track: color-mix(
+    in srgb,
+    var(--canvas-warm) 62%,
+    transparent
+  );
+  scrollbar-color: transparent transparent;
   scrollbar-width: thin;
 }
 
-.parent-drawer__scroll::-webkit-scrollbar {
+.museum-scrollbar[data-scrolling="true"],
+.museum-scrollbar:hover {
+  scrollbar-color: var(--museum-scrollbar-thumb) var(--museum-scrollbar-track);
+}
+
+.museum-scrollbar::-webkit-scrollbar {
   width: 8px;
 }
 
-.parent-drawer__scroll::-webkit-scrollbar-track {
+.museum-scrollbar::-webkit-scrollbar-track {
   border-radius: 999px;
-  background: color-mix(in srgb, var(--canvas-warm) 62%, transparent);
+  background-color: transparent;
+  transition: background-color 180ms ease;
 }
 
-.parent-drawer__scroll::-webkit-scrollbar-thumb {
+.museum-scrollbar::-webkit-scrollbar-thumb {
   border: 2px solid transparent;
   border-radius: 999px;
-  background:
-    color-mix(in srgb, var(--animal-accent, var(--leaf)) 58%, var(--leaf))
-    padding-box;
+  background-color: transparent;
+  background-clip: padding-box;
+  transition: background-color 180ms ease;
 }
 
-.parent-drawer__scroll::-webkit-scrollbar-thumb:hover {
-  background:
-    color-mix(in srgb, var(--animal-accent, var(--leaf)) 76%, var(--leaf))
-    padding-box;
+.museum-scrollbar[data-scrolling="true"]::-webkit-scrollbar-track,
+.museum-scrollbar:hover::-webkit-scrollbar-track {
+  background-color: var(--museum-scrollbar-track);
+}
+
+.museum-scrollbar[data-scrolling="true"]::-webkit-scrollbar-thumb,
+.museum-scrollbar:hover::-webkit-scrollbar-thumb {
+  background-color: var(--museum-scrollbar-thumb);
+}
+
+.museum-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--museum-scrollbar-thumb-hover);
 }
 
 .fact-grid {
@@ -3234,12 +3261,7 @@ a:focus-visible {
   }
 
   .drawer-handle {
-    top: 50%;
-    right: 7px;
-    left: auto;
-    width: 4px;
-    height: 42px;
-    transform: translateY(-50%);
+    display: none;
   }
 
   .drawer-header {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1942,6 +1942,36 @@ a:focus-visible {
   scrollbar-gutter: stable;
 }
 
+.parent-drawer__scroll {
+  scrollbar-color:
+    color-mix(in srgb, var(--animal-accent, var(--leaf)) 58%, var(--leaf))
+    color-mix(in srgb, var(--canvas-warm) 62%, transparent);
+  scrollbar-width: thin;
+}
+
+.parent-drawer__scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.parent-drawer__scroll::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--canvas-warm) 62%, transparent);
+}
+
+.parent-drawer__scroll::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background:
+    color-mix(in srgb, var(--animal-accent, var(--leaf)) 58%, var(--leaf))
+    padding-box;
+}
+
+.parent-drawer__scroll::-webkit-scrollbar-thumb:hover {
+  background:
+    color-mix(in srgb, var(--animal-accent, var(--leaf)) 76%, var(--leaf))
+    padding-box;
+}
+
 .fact-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);

--- a/tests/transient-scrollbar.test.tsx
+++ b/tests/transient-scrollbar.test.tsx
@@ -3,13 +3,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useTransientScrollbar } from '../src/components/useTransientScrollbar'
 
 function TransientScrollbarFixture() {
-  const { handleScroll, isScrolling } = useTransientScrollbar()
+  const { handleScroll, isScrolling, scrollRef } = useTransientScrollbar()
 
   return (
     <div
       data-scrolling={isScrolling}
       data-testid="scroll-container"
       onScroll={handleScroll}
+      ref={scrollRef}
     />
   )
 }
@@ -30,7 +31,7 @@ describe('useTransientScrollbar', () => {
     expect(scrollContainer).toHaveAttribute('data-scrolling', 'true')
 
     act(() => {
-      vi.advanceTimersByTime(699)
+      vi.advanceTimersByTime(479)
     })
     expect(scrollContainer).toHaveAttribute('data-scrolling', 'true')
 

--- a/tests/transient-scrollbar.test.tsx
+++ b/tests/transient-scrollbar.test.tsx
@@ -1,0 +1,42 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useTransientScrollbar } from '../src/components/useTransientScrollbar'
+
+function TransientScrollbarFixture() {
+  const { handleScroll, isScrolling } = useTransientScrollbar()
+
+  return (
+    <div
+      data-scrolling={isScrolling}
+      data-testid="scroll-container"
+      onScroll={handleScroll}
+    />
+  )
+}
+
+describe('useTransientScrollbar', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows while scrolling and hides after the idle delay', () => {
+    vi.useFakeTimers()
+    render(<TransientScrollbarFixture />)
+    const scrollContainer = screen.getByTestId('scroll-container')
+
+    expect(scrollContainer).toHaveAttribute('data-scrolling', 'false')
+
+    fireEvent.scroll(scrollContainer)
+    expect(scrollContainer).toHaveAttribute('data-scrolling', 'true')
+
+    act(() => {
+      vi.advanceTimersByTime(699)
+    })
+    expect(scrollContainer).toHaveAttribute('data-scrolling', 'true')
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(scrollContainer).toHaveAttribute('data-scrolling', 'false')
+  })
+})


### PR DESCRIPTION
## Summary

- replace browser-default drawer scrollbars with a slim museum-themed treatment
- share the treatment between the parent guide and About drawers
- remove the overlapping landscape handle and add smooth transient fade and thumb tracking

## Verification

- npm run lint
- npm run typecheck
- npm test -- --run tests/transient-scrollbar.test.tsx tests/App.test.tsx
- npm run build
- verified both drawers in headed browser at portrait and landscape sizes