### PR TITLE
docs: add branded repository badges

### DIFF
--- a/.github/workflows/update-github-stars-badge.yml
+++ b/.github/workflows/update-github-stars-badge.yml
@@ -1,0 +1,38 @@
+name: Update GitHub stars badge
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-github-stars-badge
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Fetch star count and render badge
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          stars="$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.stargazers_count')"
+          node scripts/render-github-stars-badge.mjs "$stars"
+
+      - name: Commit a changed badge
+        run: |
+          if git diff --quiet -- assets/readme/github-stars.svg; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/readme/github-stars.svg
+          git commit -m "chore: update GitHub stars badge"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/readme/hero.svg" width="100%" alt="Prehistoric Animal Museum — a free 3D world for children and grown-ups to explore together">
+  <img src="./assets/readme/hero.svg" width="100%" alt="Prehistoric Animal Museum, a free 3D world for children and grown-ups to explore together">
 </p>
 
 <p align="center">
@@ -37,7 +37,7 @@ This museum is not designed to keep children on the screen. Discovering one inte
 
 The museum follows the device language on a first visit. You can switch between English and Simplified Chinese at any time; the choice is remembered, and each language has a shareable link.
 
-It is designed mainly for children aged 2–6 with a grown-up nearby, but curiosity matters more than the age label. If an image or sound feels uncomfortable, choose another animal or close the page.
+It is designed mainly for children aged 2-6 with a grown-up nearby, but curiosity matters more than the age label. If an image or sound feels uncomfortable, choose another animal or close the page.
 
 ## Exhibits across sea, land, and sky
 
@@ -97,3 +97,22 @@ This repository has several clear legal layers:
 - “Leon做了个 / Leon Made This”, the project names, logos, and source-identifying brand elements are reserved to prevent confusion about the official source; renamed and rebranded forks remain welcome within the applicable licences.
 
 See the [licensing guide](LICENSING.md), [brand policy](BRAND_POLICY.md), [contribution terms](CONTRIBUTING.md), and [third-party notices](THIRD_PARTY_NOTICES.md) for licensing boundaries and recorded attributions, sources, and modifications.
+
+<br><br>
+
+<p align="center">
+  <a href="https://github.com/s010s/prehistoric-animal-museum/stargazers">
+    <img src="./assets/readme/github-stars.svg" height="54" alt="GitHub Stars">
+  </a>
+  &nbsp;
+  <a href="https://atomgit.com/leonleung/prehistoric-animal-museum">
+    <img src="https://atomgit.com/leonleung/prehistoric-animal-museum/star/new_badge.svg" height="54" alt="AtomGit G-Star">
+  </a>
+</p>
+
+<p align="center">
+  <sub>
+    <a href="https://github.com/s010s/prehistoric-animal-museum"><strong>GitHub</strong></a> is the primary repository for development, Issues, and pull requests.<br>
+    <a href="https://atomgit.com/leonleung/prehistoric-animal-museum"><strong>AtomGit</strong></a> is the official mirror for visitors in Mainland China.
+  </sub>
+</p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./assets/readme/hero.zh-CN.svg" width="100%" alt="史前动物博物馆——给孩子和家长一起观察的免费 3D 史前动物小世界">
+  <img src="./assets/readme/hero.zh-CN.svg" width="100%" alt="史前动物博物馆，给孩子和家长一起观察的免费 3D 史前动物小世界">
 </p>
 
 <p align="center">
@@ -97,3 +97,22 @@ npm run test:e2e
 - “Leon做了个 / Leon Made This”、项目名称、标志及用于识别官方来源的品牌元素仅保留防止冒充官方所需的权利；在适用许可范围内，改名和替换品牌后的 Fork 仍然受到欢迎。
 
 许可边界以及已记录的署名、来源和修改信息见[许可说明](LICENSING.md)、[品牌政策](BRAND_POLICY.md)、[贡献指南](CONTRIBUTING.md)与[第三方素材说明](THIRD_PARTY_NOTICES.md)。
+
+<br><br>
+
+<p align="center">
+  <a href="https://github.com/s010s/prehistoric-animal-museum/stargazers">
+    <img src="./assets/readme/github-stars.svg" height="54" alt="GitHub Stars">
+  </a>
+  &nbsp;
+  <a href="https://atomgit.com/leonleung/prehistoric-animal-museum">
+    <img src="https://atomgit.com/leonleung/prehistoric-animal-museum/star/new_badge.svg" height="54" alt="AtomGit G-Star">
+  </a>
+</p>
+
+<p align="center">
+  <sub>
+    <a href="https://github.com/s010s/prehistoric-animal-museum"><strong>GitHub</strong></a> 是项目主仓与开发协作入口，Issue 和 Pull Request 请在 GitHub 提交。<br>
+    <a href="https://atomgit.com/leonleung/prehistoric-animal-museum"><strong>AtomGit</strong></a> 是面向中国大陆访问者的官方同步镜像。
+  </sub>
+</p>

--- a/assets/readme/github-stars-template.svg
+++ b/assets/readme/github-stars-template.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="54" viewBox="0 0 240 54" role="img" aria-labelledby="title desc">
+  <title id="title">GitHub Stars for Prehistoric Animal Museum</title>
+  <desc id="desc">The primary repository on GitHub currently has {{STAR_COUNT}} stars.</desc>
+
+  <rect x="1" y="1" width="238" height="52" rx="13" fill="#fffdf7" stroke="#356859" stroke-width="2"/>
+
+  <circle cx="27" cy="27" r="15" fill="#356859"/>
+  <path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.3c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2A11.4 11.4 0 0 1 12 6c1 0 2 .1 3 .4 2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.4c0 .3.2.7.8.6A12 12 0 0 0 12 .3z" transform="translate(17 17) scale(.83)" fill="#fffdf7"/>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+    <text x="51" y="19" font-size="8.5" font-weight="700" letter-spacing=".8" fill="#356859">PRIMARY REPOSITORY</text>
+    <text x="50" y="40" font-size="20" font-weight="800" fill="#20352f">GitHub</text>
+    <path d="m181 20.5 2.2 4.5 5 .7-3.6 3.5.9 5-4.5-2.4-4.4 2.4.8-5-3.6-3.5 5-.7z" fill="#f4b85f"/>
+    <text x="225" y="38" text-anchor="end" font-size="15" font-weight="750" fill="#20352f">{{STAR_DISPLAY}}</text>
+  </g>
+</svg>

--- a/assets/readme/github-stars.svg
+++ b/assets/readme/github-stars.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="54" viewBox="0 0 240 54" role="img" aria-labelledby="title desc">
+  <title id="title">GitHub Stars for Prehistoric Animal Museum</title>
+  <desc id="desc">The primary repository on GitHub currently has 849 stars.</desc>
+
+  <rect x="1" y="1" width="238" height="52" rx="13" fill="#fffdf7" stroke="#356859" stroke-width="2"/>
+
+  <circle cx="27" cy="27" r="15" fill="#356859"/>
+  <path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.3c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2A11.4 11.4 0 0 1 12 6c1 0 2 .1 3 .4 2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.4c0 .3.2.7.8.6A12 12 0 0 0 12 .3z" transform="translate(17 17) scale(.83)" fill="#fffdf7"/>
+
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
+    <text x="51" y="19" font-size="8.5" font-weight="700" letter-spacing=".8" fill="#356859">PRIMARY REPOSITORY</text>
+    <text x="50" y="40" font-size="20" font-weight="800" fill="#20352f">GitHub</text>
+    <path d="m181 20.5 2.2 4.5 5 .7-3.6 3.5.9 5-4.5-2.4-4.4 2.4.8-5-3.6-3.5 5-.7z" fill="#f4b85f"/>
+    <text x="225" y="38" text-anchor="end" font-size="15" font-weight="750" fill="#20352f">849</text>
+  </g>
+</svg>

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -34,7 +34,7 @@
     </g>
     <text x="0" y="123" font-size="60" font-weight="800" fill="#20352f">Prehistoric</text>
     <text x="0" y="196" font-size="60" font-weight="800" fill="#20352f">Animal Museum</text>
-    <text x="2" y="249" font-size="25" font-weight="600" fill="#356859">Turn, look, and listen — together</text>
+    <text x="2" y="249" font-size="25" font-weight="600" fill="#356859">Turn, look, and listen together</text>
     <text x="2" y="288" font-size="21" fill="#5c6e68">A free 3D world for curious families</text>
 
     <g transform="translate(0 322)" font-size="18" font-weight="700">

--- a/scripts/render-github-stars-badge.mjs
+++ b/scripts/render-github-stars-badge.mjs
@@ -1,0 +1,27 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const count = Number.parseInt(process.argv[2] ?? '', 10);
+
+if (!Number.isSafeInteger(count) || count < 0) {
+  throw new Error('Pass a non-negative integer GitHub star count.');
+}
+
+function formatStars(value) {
+  if (value < 1_000) return String(value);
+  if (value < 10_000) {
+    const rounded = (value / 1_000).toFixed(1).replace(/\.0$/, '');
+    return `${rounded}k`;
+  }
+  return `${Math.round(value / 1_000)}k`;
+}
+
+const templateUrl = new URL('../assets/readme/github-stars-template.svg', import.meta.url);
+const outputUrl = new URL('../assets/readme/github-stars.svg', import.meta.url);
+const template = readFileSync(templateUrl, 'utf8');
+const rendered = template
+  .replaceAll('{{STAR_COUNT}}', String(count))
+  .replaceAll('{{STAR_DISPLAY}}', formatStars(count));
+
+writeFileSync(outputUrl, rendered, 'utf8');
+console.log(`Rendered ${fileURLToPath(outputUrl)} with ${count} GitHub stars.`);

--- a/tests/readme-screenshots.test.ts
+++ b/tests/readme-screenshots.test.ts
@@ -70,8 +70,13 @@ describe('README reference screenshot plan', () => {
         (match) => match[1] ?? '',
       ),
     ]
+    const sharedReadmeGraphics = new Set([
+      './assets/readme/github-stars.svg',
+      'https://atomgit.com/leonleung/prehistoric-animal-museum/star/new_badge.svg',
+    ])
     const isAllowedReadmeImage = (source: string, hero: string) =>
       source === hero ||
+      sharedReadmeGraphics.has(source) ||
       /^\.\/src\/content\/animals\/[a-z0-9-]+\/images\/thumbnail\.webp$/u.test(
         source,
       )
@@ -88,6 +93,8 @@ describe('README reference screenshot plan', () => {
     ).toBe(true)
     expect(englishReadme).toContain('./assets/readme/hero.svg')
     expect(chineseReadme).toContain('./assets/readme/hero.zh-CN.svg')
+    expect(englishReadme).toContain('./assets/readme/github-stars.svg')
+    expect(chineseReadme).toContain('./assets/readme/github-stars.svg')
     expect(englishReadme).toContain('/images/thumbnail.webp')
     expect(chineseReadme).toContain('/images/thumbnail.webp')
   })


### PR DESCRIPTION
Adds a branded GitHub Stars badge paired with the AtomGit G-Star badge at the bottom of both READMEs. Documents GitHub as the primary repository and AtomGit as the official Mainland China mirror. Includes an hourly workflow that refreshes the local GitHub star-count SVG only when the count changes.