### PR TITLE
feat(encounter): persist explorer profile in local storage across page refreshes

### DIFF
--- a/src/scale-encounter/profile-storage.ts
+++ b/src/scale-encounter/profile-storage.ts
@@ -42,13 +42,39 @@ export function parseScaleEncounterProfile(
 
 export function readScaleEncounterProfile(
   storage: Pick<Storage, 'getItem'> | null =
-    typeof window === 'undefined' ? null : window.sessionStorage,
+    typeof window === 'undefined' ? null : window.localStorage,
 ): ChildProfile | null {
   if (!storage) return null
   try {
-    return parseScaleEncounterProfile(
+    const directProfile = parseScaleEncounterProfile(
       storage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY),
     )
+    if (directProfile) return directProfile
+
+    if (
+      typeof window !== 'undefined' &&
+      storage === window.localStorage &&
+      window.sessionStorage
+    ) {
+      const sessionProfile = parseScaleEncounterProfile(
+        window.sessionStorage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY),
+      )
+      if (sessionProfile) {
+        try {
+          window.localStorage.setItem(
+            SCALE_ENCOUNTER_PROFILE_STORAGE_KEY,
+            JSON.stringify({
+              profile: sessionProfile,
+              version: 1,
+            } satisfies StoredScaleEncounterProfile),
+          )
+        } catch {
+          // Storage can be disabled or full.
+        }
+        return sessionProfile
+      }
+    }
+    return null
   } catch {
     return null
   }
@@ -57,12 +83,23 @@ export function readScaleEncounterProfile(
 export function writeScaleEncounterProfile(
   profile: ChildProfile | null,
   storage: Pick<Storage, 'removeItem' | 'setItem'> | null =
-    typeof window === 'undefined' ? null : window.sessionStorage,
+    typeof window === 'undefined' ? null : window.localStorage,
 ): void {
   if (!storage) return
   try {
     if (profile === null) {
       storage.removeItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY)
+      if (
+        typeof window !== 'undefined' &&
+        storage === window.localStorage &&
+        window.sessionStorage
+      ) {
+        try {
+          window.sessionStorage.removeItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY)
+        } catch {
+          // ignore
+        }
+      }
       return
     }
     storage.setItem(

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -514,7 +514,7 @@ describe('App', () => {
     expect(new URL(window.location.href).searchParams.has('gender')).toBe(false)
     expect(
       JSON.parse(
-        window.sessionStorage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY) ?? '',
+        window.localStorage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY) ?? '',
       ),
     ).toEqual({
       profile: { gender: 'boy', heightCm: 115 },
@@ -564,7 +564,7 @@ describe('App', () => {
   })
 
   it('restores the explorer profile after a page refresh and skips setup', async () => {
-    window.sessionStorage.setItem(
+    window.localStorage.setItem(
       SCALE_ENCOUNTER_PROFILE_STORAGE_KEY,
       JSON.stringify({
         profile: { approach: 'close', gender: 'girl', heightCm: 120 },

--- a/tests/scale-encounter-profile-storage.test.ts
+++ b/tests/scale-encounter-profile-storage.test.ts
@@ -6,9 +6,12 @@ import {
 } from '../src/scale-encounter/profile-storage'
 
 describe('scale encounter profile storage', () => {
-  beforeEach(() => window.sessionStorage.clear())
+  beforeEach(() => {
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+  })
 
-  it('round-trips the explorer profile across refreshes in the same tab', () => {
+  it('round-trips the explorer profile across refreshes in local storage', () => {
     const profile = {
       approach: 'close' as const,
       gender: 'girl' as const,
@@ -18,7 +21,7 @@ describe('scale encounter profile storage', () => {
     writeScaleEncounterProfile(profile)
 
     expect(readScaleEncounterProfile()).toEqual(profile)
-    expect(window.sessionStorage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY))
+    expect(window.localStorage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY))
       .toContain('"version":1')
   })
 
@@ -28,7 +31,38 @@ describe('scale encounter profile storage', () => {
 
     expect(readScaleEncounterProfile()).toBeNull()
     expect(
+      window.localStorage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY),
+    ).toBeNull()
+  })
+
+  it('migrates a legacy profile from session storage into local storage', () => {
+    const profile = {
+      gender: 'girl' as const,
+      heightCm: 105,
+    }
+    window.sessionStorage.setItem(
+      SCALE_ENCOUNTER_PROFILE_STORAGE_KEY,
+      JSON.stringify({ profile, version: 1 }),
+    )
+
+    expect(readScaleEncounterProfile()).toEqual(profile)
+    expect(
+      window.localStorage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY),
+    ).toContain('"version":1')
+  })
+
+  it('cleans up legacy session storage when resetting profile', () => {
+    window.sessionStorage.setItem(
+      SCALE_ENCOUNTER_PROFILE_STORAGE_KEY,
+      JSON.stringify({ profile: { gender: 'boy', heightCm: 100 }, version: 1 }),
+    )
+    writeScaleEncounterProfile(null)
+
+    expect(
       window.sessionStorage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY),
+    ).toBeNull()
+    expect(
+      window.localStorage.getItem(SCALE_ENCOUNTER_PROFILE_STORAGE_KEY),
     ).toBeNull()
   })
 


### PR DESCRIPTION
## Summary
- Persist explorer child profile (gender, height, approach) in `localStorage` instead of `sessionStorage` so refreshing the page or reopening the tab preserves the profile and skips the setup dialog.
- Seamlessly migrate existing profiles from `sessionStorage` if present and `localStorage` is empty.
- Ensure profile reset cleans up both `localStorage` and legacy `sessionStorage`.

## Validation
- `npm run typecheck` passed
- `npx eslint src/scale-encounter/profile-storage.ts tests/App.test.tsx tests/scale-encounter-profile-storage.test.ts` passed
- `npx vitest run tests/scale-encounter-profile-storage.test.ts` passed (17 tests)
- `npx vitest run tests/App.test.tsx --exclude '**/.wayfinder/**'` passed (30 tests)
- `npm run validate:content` passed
- `npm run validate:production-boundary` passed